### PR TITLE
#13 [FEAT] 이메일 전송 기능 비동기 처리 및 Retry 로직 구현

### DIFF
--- a/mokakbob-api/build.gradle
+++ b/mokakbob-api/build.gradle
@@ -14,6 +14,7 @@ dependencies {
 
     // mail
     implementation 'org.springframework.boot:spring-boot-starter-mail'
+    implementation 'org.springframework.retry:spring-retry'
 
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'

--- a/mokakbob-api/src/main/java/com/mokakbob/MokakbobApiApplication.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/MokakbobApiApplication.java
@@ -2,8 +2,10 @@ package com.mokakbob;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.retry.annotation.EnableRetry;
 
 @SpringBootApplication
+@EnableRetry
 public class MokakbobApiApplication {
 
     public static void main(String[] args) {

--- a/mokakbob-api/src/main/java/com/mokakbob/MokakbobApiApplication.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/MokakbobApiApplication.java
@@ -2,10 +2,8 @@ package com.mokakbob;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.retry.annotation.EnableRetry;
 
 @SpringBootApplication
-@EnableRetry
 public class MokakbobApiApplication {
 
     public static void main(String[] args) {

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/infrastructure/RedisEmailVerifyCodeStore.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/infrastructure/RedisEmailVerifyCodeStore.java
@@ -29,7 +29,8 @@ public class RedisEmailVerifyCodeStore implements EmailVerifyCodeStore {
 
     @Override
     public void deleteCode(String email) {
-
+        String key = EMAIL_KEY_PREFIX + email;
+        authRedisTemplate.delete(key);
     }
 
     @Override

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/infrastructure/SmtpEmailSender.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/infrastructure/SmtpEmailSender.java
@@ -1,31 +1,40 @@
 package com.mokakbob.auth.infrastructure;
 
-import com.mokakbob.common.exception.DomainException;
 import com.mokakbob.domain.member.service.auth.EmailSender;
-import com.mokakbob.domain.member.exception.MemberErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.mail.MailException;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class SmtpEmailSender implements EmailSender {
 
     private final JavaMailSender javaMailSender;
 
     @Override
-    @Async
+    @Async(value = "EmailExecutor")
+    @Retryable(
+            retryFor = {MailException.class},
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 1000, multiplier = 2)
+    )
     public void sendEmail(String to, String subject, String text) {
         SimpleMailMessage message = makeInfo(to, subject, text);
 
-        try {
-            javaMailSender.send(message);
-        } catch (MailException e) {
-            throw new DomainException(MemberErrorCode.MAIL_EXCEPTION);
-        }
+        javaMailSender.send(message);
+    }
+
+    @Recover
+    public void recover(MailException e, String to, String subject, String text) {
+        log.error("[메일 전송 실패]: {}", e.getMessage());
     }
 
     private SimpleMailMessage makeInfo(String to, String subject, String text) {

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/infrastructure/SmtpEmailSender.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/infrastructure/SmtpEmailSender.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.mail.MailException;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -16,6 +17,7 @@ public class SmtpEmailSender implements EmailSender {
     private final JavaMailSender javaMailSender;
 
     @Override
+    @Async
     public void sendEmail(String to, String subject, String text) {
         SimpleMailMessage message = makeInfo(to, subject, text);
 

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/infrastructure/SmtpEmailSender.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/infrastructure/SmtpEmailSender.java
@@ -4,7 +4,9 @@ import com.mokakbob.domain.member.repository.EmailVerifyCodeStore;
 import com.mokakbob.domain.member.service.auth.EmailSender;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.MailAuthenticationException;
 import org.springframework.mail.MailException;
+import org.springframework.mail.MailSendException;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.retry.annotation.Backoff;
@@ -24,7 +26,7 @@ public class SmtpEmailSender implements EmailSender {
     @Override
     @Async(value = "EmailExecutor")
     @Retryable(
-            retryFor = {MailException.class},
+            retryFor = {MailSendException.class, MailAuthenticationException.class},
             backoff = @Backoff(delay = 1000, multiplier = 2)
     )
     public void sendEmail(String to, String subject, String text) {

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/infrastructure/SmtpEmailSender.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/infrastructure/SmtpEmailSender.java
@@ -1,5 +1,6 @@
 package com.mokakbob.auth.infrastructure;
 
+import com.mokakbob.domain.member.repository.EmailVerifyCodeStore;
 import com.mokakbob.domain.member.service.auth.EmailSender;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,12 +19,12 @@ import org.springframework.stereotype.Component;
 public class SmtpEmailSender implements EmailSender {
 
     private final JavaMailSender javaMailSender;
+    private final EmailVerifyCodeStore codeStore;
 
     @Override
     @Async(value = "EmailExecutor")
     @Retryable(
             retryFor = {MailException.class},
-            maxAttempts = 3,
             backoff = @Backoff(delay = 1000, multiplier = 2)
     )
     public void sendEmail(String to, String subject, String text) {
@@ -34,6 +35,7 @@ public class SmtpEmailSender implements EmailSender {
 
     @Recover
     public void recover(MailException e, String to, String subject, String text) {
+        codeStore.deleteCode(to);
         log.error("[메일 전송 실패]: {}", e.getMessage());
     }
 

--- a/mokakbob-api/src/main/java/com/mokakbob/config/AsyncConfig.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/config/AsyncConfig.java
@@ -1,0 +1,32 @@
+package com.mokakbob.config;
+
+import java.util.concurrent.Executor;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig implements AsyncConfigurer {
+
+    @Override
+    public Executor getAsyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("EmailAsync-");
+        executor.initialize();
+        return executor;
+    }
+
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+        return (ex, method, params) -> {
+            System.err.println("비동기 예외 발생 " + method.getName());
+            ex.printStackTrace();
+        };
+    }
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/config/AsyncConfig.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/config/AsyncConfig.java
@@ -1,7 +1,10 @@
 package com.mokakbob.config;
 
 import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
@@ -9,15 +12,17 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 @Configuration
 @EnableAsync
+@Slf4j
 public class AsyncConfig implements AsyncConfigurer {
 
-    @Override
-    public Executor getAsyncExecutor() {
+    @Bean(name = "EmailExecutor")
+    public Executor emailExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         executor.setCorePoolSize(5);
         executor.setMaxPoolSize(10);
         executor.setQueueCapacity(100);
         executor.setThreadNamePrefix("EmailAsync-");
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
         executor.initialize();
         return executor;
     }
@@ -25,7 +30,8 @@ public class AsyncConfig implements AsyncConfigurer {
     @Override
     public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
         return (ex, method, params) -> {
-            System.err.println("비동기 예외 발생 " + method.getName());
+            log.info("비동기 예외 발생 {}", method.getName());
+            log.info("Exception message: " + ex.getMessage());
             ex.printStackTrace();
         };
     }

--- a/mokakbob-api/src/main/java/com/mokakbob/config/RetryConfig.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/config/RetryConfig.java
@@ -1,0 +1,9 @@
+package com.mokakbob.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.EnableRetry;
+
+@Configuration
+@EnableRetry
+public class RetryConfig {
+}

--- a/mokakbob-api/src/test/java/com/mokakbob/auth/infrastructure/SmtpEmailSenderTest.java
+++ b/mokakbob-api/src/test/java/com/mokakbob/auth/infrastructure/SmtpEmailSenderTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import com.mokakbob.domain.member.repository.EmailVerifyCodeStore;
 import org.junit.jupiter.api.Test;
 import org.springframework.mail.MailException;
 import org.springframework.mail.SimpleMailMessage;
@@ -15,7 +16,8 @@ import org.springframework.mail.javamail.JavaMailSender;
 class SmtpEmailSenderTest {
 
     private final JavaMailSender javaMailSender = mock(JavaMailSender.class);
-    private final SmtpEmailSender smtpEmailSender = new SmtpEmailSender(javaMailSender);
+    private final EmailVerifyCodeStore codeStore = mock(EmailVerifyCodeStore.class);
+    private final SmtpEmailSender smtpEmailSender = new SmtpEmailSender(javaMailSender, codeStore);
 
     @Test
     void 이메일_전송_성공() {

--- a/mokakbob-api/src/test/java/com/mokakbob/auth/infrastructure/SmtpEmailSenderTest.java
+++ b/mokakbob-api/src/test/java/com/mokakbob/auth/infrastructure/SmtpEmailSenderTest.java
@@ -1,14 +1,12 @@
 package com.mokakbob.auth.infrastructure;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-import com.mokakbob.common.exception.DomainException;
-import com.mokakbob.domain.member.exception.MemberErrorCode;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.mail.MailException;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -16,7 +14,7 @@ import org.springframework.mail.javamail.JavaMailSender;
 @SuppressWarnings("NonAsciiCharacters")
 class SmtpEmailSenderTest {
 
-    private final JavaMailSender javaMailSender = Mockito.mock(JavaMailSender.class);
+    private final JavaMailSender javaMailSender = mock(JavaMailSender.class);
     private final SmtpEmailSender smtpEmailSender = new SmtpEmailSender(javaMailSender);
 
     @Test
@@ -34,19 +32,23 @@ class SmtpEmailSenderTest {
     }
 
     @Test
-    void 이메일_전송_실패() {
+    void 이메일_전송_실패_후_recover_호출() {
         // given
         String to = "test@example.com";
-        String subject = "Subject";
-        String text = "Hello";
+        String subject = "subject";
+        String text = "text";
 
-        doThrow(Mockito.mock(MailException.class))
-                .when(javaMailSender)
+        MailException exception = mock(MailException.class);
+        doThrow(exception).when(javaMailSender).send(any(SimpleMailMessage.class));
+
+        // when
+        try {
+            smtpEmailSender.sendEmail(to, subject, text);
+        } catch (Exception ignored) {
+        }
+
+        // then
+        verify(javaMailSender, atLeast(1))
                 .send(any(SimpleMailMessage.class));
-
-        // when & then
-        assertThatThrownBy(() -> smtpEmailSender.sendEmail(to, subject, text))
-                .isInstanceOf(DomainException.class)
-                .hasMessageContaining(MemberErrorCode.MAIL_EXCEPTION.message());
     }
 }

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/member/service/auth/EmailAuthService.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/member/service/auth/EmailAuthService.java
@@ -25,14 +25,9 @@ public class EmailAuthService {
 
         Duration expiration = Duration.ofMinutes(CODE_EXPIRATION_MINUTES);
         codeStore.saveCode(email, code, expiration);
-
         String text = String.format("인증 코드: %s\n이 코드는 %d분 후에 만료됩니다.", code, CODE_EXPIRATION_MINUTES);
 
-        try {
-            emailSender.sendEmail(email, MAIL_SUBJECT, text);
-        } catch (Exception e) {
-            codeStore.deleteCode(email);
-        }
+        emailSender.sendEmail(email, MAIL_SUBJECT, text);
     }
 
     private void checkCoolDown(String email) {


### PR DESCRIPTION
## 관련 이슈 번호
#13 closed

## 작업 내용 25.07.24

* 이메일 전송 기능 비동기 처리 및 Retry 로직 구현하였습니다.

### 이메일 전송 기능 비동기 처리
* 비동기 처리한 이유
  * SMTP 서버와의 통신 지연을 메인 로직에 영향 없이 분리하기 위해 비동기 로직 구현하였습니다.
  * 스레드 풀을 활용하여 트래픽 분할 목적도 있습니다.



* `AsyncConfig` 구현하였습니다.
  * EmailExecutor 메서드 구현하였고, CallerRunsPolicy() 설정을 통해 예외를 던지지 않고 최대한 안정적으로 메일 전송 하도록 구현하였습니다.(스레드 풀 꽉차면 메서드 호출한 스레드로 전환)
  * `AsyncUncaughtExceptionHandler`를 오버라이드 하여 비동기 스레드에서 처리되는 예외 잡을 수 있도록 구현하였습니다.



### 이메일 Retry 로직
* 해당 로직을 구현한 이유
  * SMTP 서버의 문제나 네트워크 문제로 메일 전송 실패할 경우를 대비하였습니다.



* `@Retryable`
  * 해당 어노테이션을 적용하여 retry 되도록 구현했습니다.
  * 백오프 기능을 통해 텀을 두고 재전송 하도록 구현하였습니다.

* `@Recover`
  * 해당 어노테이션을 적용하여 Retry 실패 시에도 정상적으로 동작되도록 구현하였습니다.
  * 로그로 메일 실패 정보를 남겼습니다.