### PR TITLE
#15 [FEAT] 이메일 본인 확인 코드 검증 로직 작성

### DIFF
--- a/mokakbob-api/src/main/java/com/mokakbob/auth/config/AsyncConfig.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/config/AsyncConfig.java
@@ -1,4 +1,4 @@
-package com.mokakbob.config;
+package com.mokakbob.auth.config;
 
 import java.util.concurrent.Executor;
 import java.util.concurrent.ThreadPoolExecutor;

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/config/RetryConfig.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/config/RetryConfig.java
@@ -1,4 +1,4 @@
-package com.mokakbob.config;
+package com.mokakbob.auth.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.retry.annotation.EnableRetry;

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/controller/AuthEmailController.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/controller/AuthEmailController.java
@@ -2,7 +2,7 @@ package com.mokakbob.auth.controller;
 
 import com.mokakbob.auth.controller.request.EmailCodeRequest;
 import com.mokakbob.common.path.EmailApiPath;
-import com.mokakbob.domain.member.service.auth.EmailAuthService;
+import com.mokakbob.auth.service.EmailAuthService;
 import com.mokakbob.auth.controller.request.EmailSendRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/controller/AuthEmailController.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/controller/AuthEmailController.java
@@ -1,6 +1,7 @@
 package com.mokakbob.auth.controller;
 
 import com.mokakbob.auth.controller.request.EmailCodeRequest;
+import com.mokakbob.common.path.EmailApiPath;
 import com.mokakbob.domain.member.service.auth.EmailAuthService;
 import com.mokakbob.auth.controller.request.EmailSendRequest;
 import jakarta.validation.Valid;
@@ -8,24 +9,22 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/auth")
 @RequiredArgsConstructor
 public class AuthEmailController {
 
     private final EmailAuthService emailAuthService;
 
-    @PostMapping("/email/send")
+    @PostMapping(EmailApiPath.SEND)
     public ResponseEntity<Void> sendEmailVerificationCode(@Valid @RequestBody EmailSendRequest request) {
         emailAuthService.sendEmail(request.email());
         return ResponseEntity.ok()
                 .build();
     }
 
-    @PostMapping("/email/verify")
+    @PostMapping(EmailApiPath.VERIFY)
     public ResponseEntity<Void> verifyEmailCode(@Valid @RequestBody EmailCodeRequest request) {
         emailAuthService.checkEmailCode(request.email(), request.code());
         return ResponseEntity.ok()

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/controller/AuthEmailController.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/controller/AuthEmailController.java
@@ -1,5 +1,6 @@
 package com.mokakbob.auth.controller;
 
+import com.mokakbob.auth.controller.request.EmailCodeRequest;
 import com.mokakbob.domain.member.service.auth.EmailAuthService;
 import com.mokakbob.auth.controller.request.EmailSendRequest;
 import jakarta.validation.Valid;
@@ -17,9 +18,16 @@ public class AuthEmailController {
 
     private final EmailAuthService emailAuthService;
 
-    @PostMapping("/send")
+    @PostMapping("/email/send")
     public ResponseEntity<Void> sendEmailVerificationCode(@Valid @RequestBody EmailSendRequest request) {
         emailAuthService.sendEmail(request.email());
+        return ResponseEntity.ok()
+                .build();
+    }
+
+    @PostMapping("/email/verify")
+    public ResponseEntity<Void> verifyEmailCode(@Valid @RequestBody EmailCodeRequest request) {
+        emailAuthService.checkEmailCode(request.email(), request.code());
         return ResponseEntity.ok()
                 .build();
     }

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/controller/request/EmailCodeRequest.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/controller/request/EmailCodeRequest.java
@@ -1,0 +1,14 @@
+package com.mokakbob.auth.controller.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record EmailCodeRequest(
+        @NotBlank
+        @Email
+        String email,
+
+        @NotBlank
+        String code
+) {
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/infrastructure/RedisEmailVerifyCodeStore.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/infrastructure/RedisEmailVerifyCodeStore.java
@@ -24,7 +24,10 @@ public class RedisEmailVerifyCodeStore implements EmailVerifyCodeStore {
 
     @Override
     public Optional<String> getCode(String email) {
-        return Optional.empty();
+        String key = EMAIL_KEY_PREFIX + email;
+
+        return Optional.ofNullable(authRedisTemplate.opsForValue()
+                .get(key));
     }
 
     @Override

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/infrastructure/SmtpEmailSender.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/infrastructure/SmtpEmailSender.java
@@ -4,7 +4,9 @@ import com.mokakbob.domain.member.repository.EmailVerifyCodeStore;
 import com.mokakbob.domain.member.service.auth.EmailSender;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.MailAuthenticationException;
 import org.springframework.mail.MailException;
+import org.springframework.mail.MailSendException;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.retry.annotation.Backoff;
@@ -24,7 +26,7 @@ public class SmtpEmailSender implements EmailSender {
     @Override
     @Async(value = "EmailExecutor")
     @Retryable(
-            retryFor = {MailException.class},
+            retryFor = {MailSendException.class, MailAuthenticationException.class},
             backoff = @Backoff(delay = 1000, multiplier = 2)
     )
     public void sendEmail(String to, String subject, String text) {

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/infrastructure/SmtpEmailSender.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/infrastructure/SmtpEmailSender.java
@@ -1,7 +1,7 @@
 package com.mokakbob.auth.infrastructure;
 
 import com.mokakbob.domain.member.repository.EmailVerifyCodeStore;
-import com.mokakbob.domain.member.service.auth.EmailSender;
+import com.mokakbob.auth.service.EmailSender;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.mail.MailAuthenticationException;

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/service/EmailAuthService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/service/EmailAuthService.java
@@ -1,9 +1,9 @@
-package com.mokakbob.domain.member.service.auth;
+package com.mokakbob.auth.service;
 
 import com.mokakbob.common.exception.DomainException;
 import com.mokakbob.domain.member.exception.MemberErrorCode;
 import com.mokakbob.domain.member.repository.EmailVerifyCodeStore;
-import com.mokakbob.domain.member.util.RandomNumberGenerator;
+import com.mokakbob.auth.util.RandomNumberGenerator;
 import java.time.Duration;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/service/EmailSender.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/service/EmailSender.java
@@ -1,4 +1,4 @@
-package com.mokakbob.domain.member.service.auth;
+package com.mokakbob.auth.service;
 
 public interface EmailSender {
     void sendEmail(String to, String subject, String text);

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/util/RandomNumberGenerator.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/util/RandomNumberGenerator.java
@@ -1,4 +1,4 @@
-package com.mokakbob.domain.member.util;
+package com.mokakbob.auth.util;
 
 import java.security.SecureRandom;
 

--- a/mokakbob-api/src/main/java/com/mokakbob/common/path/ApiVersion.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/common/path/ApiVersion.java
@@ -1,0 +1,6 @@
+package com.mokakbob.common.path;
+
+public class ApiVersion {
+    public static final String BASE = "/api";
+    public static final String V1 = BASE + "/v1";
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/common/path/EmailApiPath.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/common/path/EmailApiPath.java
@@ -1,0 +1,9 @@
+package com.mokakbob.common.path;
+
+public class EmailApiPath {
+
+    private static final String BASE = ApiVersion.V1 + "/email";
+
+    public static final String SEND = BASE + "/send";
+    public static final String VERIFY = BASE + "/verify";
+}

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/member/exception/MemberErrorCode.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/member/exception/MemberErrorCode.java
@@ -4,10 +4,9 @@ import com.mokakbob.common.exception.DomainErrorCode;
 
 public enum MemberErrorCode implements DomainErrorCode {
     // auth mail exception
-    MAIL_EXCEPTION(400, "E001", "메일 전송 중 오류 발생."),
-    NOT_FOUND_MAIL_CODE(404, "E002", "유효한 인증 코드를 찾을 수 없습니다."),
-    NOT_MATCH_MAIL_CODE(400, "E003", "인증 코드가 일치하지 않습니다."),
-    TOO_MANY_REQUEST(400, "E004", "잠시 후 요청해주세요.")
+    NOT_MATCH_MAIL_CODE(400, "E001", "인증 코드가 일치하지 않습니다."),
+    TOO_MANY_REQUEST(400, "E002", "잠시 후 요청해주세요."),
+    NOT_EXIST_MAIL_CODE(404, "E003", "코드 값이 존재하지 않습니다.")
     ;
 
     private final int httpStatus;

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/member/service/auth/EmailAuthService.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/member/service/auth/EmailAuthService.java
@@ -38,6 +38,8 @@ public class EmailAuthService {
         if (!Objects.equals(redisMemberCode, code)) {
             throw new DomainException(MemberErrorCode.NOT_MATCH_MAIL_CODE);
         }
+
+        codeStore.deleteCode(email);
     }
 
     private void checkCoolDown(String email) {

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/member/service/auth/EmailAuthService.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/member/service/auth/EmailAuthService.java
@@ -5,6 +5,7 @@ import com.mokakbob.domain.member.exception.MemberErrorCode;
 import com.mokakbob.domain.member.repository.EmailVerifyCodeStore;
 import com.mokakbob.domain.member.util.RandomNumberGenerator;
 import java.time.Duration;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -28,6 +29,15 @@ public class EmailAuthService {
         String text = String.format("인증 코드: %s\n이 코드는 %d분 후에 만료됩니다.", code, CODE_EXPIRATION_MINUTES);
 
         emailSender.sendEmail(email, MAIL_SUBJECT, text);
+    }
+
+    public void checkEmailCode(String email, String code) {
+        String redisMemberCode = codeStore.getCode(email)
+                .orElseThrow(() -> new DomainException(MemberErrorCode.NOT_EXIST_MAIL_CODE));
+
+        if (!Objects.equals(redisMemberCode, code)) {
+            throw new DomainException(MemberErrorCode.NOT_MATCH_MAIL_CODE);
+        }
     }
 
     private void checkCoolDown(String email) {


### PR DESCRIPTION
## 관련 이슈 번호
#15 closed

## 작업 내용

* 이메일 본인 확인 코드 검증 로직 작성


1. Redis 에서 특정 이메일로 조회
2. 코드가 있다면 코드를 가져온 후, 사용자에게 받은 코드와 매치 진행(코드가 없다면 예외처리)
3. Redis 에 해당 이메일 저장 값 삭제