### PR TITLE
#11 [FEAT] JWT Token Provider 구현

### DIFF
--- a/mokakbob-api/build.gradle
+++ b/mokakbob-api/build.gradle
@@ -18,6 +18,11 @@ dependencies {
 
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    // jwt
+    implementation("io.jsonwebtoken:jjwt-api:0.11.5")
+    runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
+    runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5")
 }
 
 springBoot {

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/domain/EmailSender.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/domain/EmailSender.java
@@ -1,4 +1,4 @@
-package com.mokakbob.auth.service;
+package com.mokakbob.auth.domain;
 
 public interface EmailSender {
     void sendEmail(String to, String subject, String text);

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/domain/EmailVerifyCodeStore.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/domain/EmailVerifyCodeStore.java
@@ -1,4 +1,4 @@
-package com.mokakbob.domain.member.repository;
+package com.mokakbob.auth.domain;
 
 import java.time.Duration;
 import java.util.Optional;

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/domain/TokenProvider.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/domain/TokenProvider.java
@@ -1,4 +1,4 @@
-package com.mokakbob.auth.service;
+package com.mokakbob.auth.domain;
 
 public interface TokenProvider {
     String create(Long memberId);

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/exception/AuthApiErrorCode.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/exception/AuthApiErrorCode.java
@@ -1,0 +1,41 @@
+package com.mokakbob.auth.exception;
+
+import com.mokakbob.common.exception.exceptions.ApiErrorCode;
+
+public enum AuthApiErrorCode implements ApiErrorCode {
+    // auth mail exception
+    NOT_MATCH_MAIL_CODE(400, "E001", "인증 코드가 일치하지 않습니다."),
+    TOO_MANY_REQUEST(400, "E002", "잠시 후 요청해주세요."),
+    NOT_EXIST_MAIL_CODE(404, "E003", "코드 값이 존재하지 않습니다."),
+
+    // token exception
+    TOKEN_EXPIRED(401, "JWT001", "토큰이 만료되었습니다."),
+    TOKEN_INVALID_SIGNATURE(401, "JWT002", "토큰 서명이 유효하지 않습니다."),
+    TOKEN_INVALID(401, "JWT003", "유효하지 않은 토큰입니다.")
+    ;
+
+    private final int httpStatus;
+    private final String customCode;
+    private final String message;
+
+    AuthApiErrorCode(int httpStatus, String customCode, String message) {
+        this.httpStatus = httpStatus;
+        this.customCode = customCode;
+        this.message = message;
+    }
+
+    @Override
+    public int httpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String customCode() {
+        return customCode;
+    }
+
+    @Override
+    public String message() {
+        return message;
+    }
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/infrastructure/JwtTokenProvider.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/infrastructure/JwtTokenProvider.java
@@ -1,0 +1,67 @@
+package com.mokakbob.auth.infrastructure;
+
+import com.mokakbob.auth.domain.TokenProvider;
+import com.mokakbob.auth.exception.AuthApiErrorCode;
+import com.mokakbob.common.exception.exceptions.ApiException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+import java.security.Key;
+import java.util.Date;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtTokenProvider implements TokenProvider {
+
+    private final Key secretKey;
+    private final long expirationPeriod;
+
+    public JwtTokenProvider(
+            @Value("${jwt.secret}") String secretKey,
+            @Value("${jwt.expiration-period}") long expirationPeriod
+    ) {
+        this.secretKey = Keys.hmacShaKeyFor(secretKey.getBytes());
+        this.expirationPeriod = expirationPeriod;
+    }
+
+    @Override
+    public String create(Long memberId) {
+        Date now = new Date();
+        Date expire = new Date(now.getTime() + expirationPeriod);
+
+        return Jwts.builder()
+                .setSubject(String.valueOf(memberId))
+                .setIssuedAt(now)
+                .setExpiration(expire)
+                .signWith(secretKey, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    @Override
+    public Long extractMemberId(String token) {
+        Claims claims = parseToken(token);
+        return Long.valueOf(claims.getSubject());
+    }
+
+    private Claims parseToken(String token) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(secretKey)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+
+        } catch (ExpiredJwtException e) {
+            throw new ApiException(AuthApiErrorCode.TOKEN_EXPIRED);
+        } catch (SignatureException e) {
+            throw new ApiException(AuthApiErrorCode.TOKEN_INVALID_SIGNATURE);
+        } catch (JwtException | IllegalArgumentException e) {
+            throw new ApiException(AuthApiErrorCode.TOKEN_INVALID);
+        }
+    }
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/infrastructure/RedisEmailVerifyCodeStore.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/infrastructure/RedisEmailVerifyCodeStore.java
@@ -1,6 +1,6 @@
 package com.mokakbob.auth.infrastructure;
 
-import com.mokakbob.domain.member.repository.EmailVerifyCodeStore;
+import com.mokakbob.auth.domain.EmailVerifyCodeStore;
 import java.time.Duration;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/infrastructure/SmtpEmailSender.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/infrastructure/SmtpEmailSender.java
@@ -1,7 +1,7 @@
 package com.mokakbob.auth.infrastructure;
 
-import com.mokakbob.domain.member.repository.EmailVerifyCodeStore;
-import com.mokakbob.auth.service.EmailSender;
+import com.mokakbob.auth.domain.EmailVerifyCodeStore;
+import com.mokakbob.auth.domain.EmailSender;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.mail.MailAuthenticationException;

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/service/EmailAuthService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/service/EmailAuthService.java
@@ -1,8 +1,9 @@
 package com.mokakbob.auth.service;
 
-import com.mokakbob.common.exception.DomainException;
-import com.mokakbob.domain.member.exception.MemberErrorCode;
-import com.mokakbob.domain.member.repository.EmailVerifyCodeStore;
+import com.mokakbob.auth.domain.EmailSender;
+import com.mokakbob.auth.exception.AuthApiErrorCode;
+import com.mokakbob.common.exception.exceptions.ApiException;
+import com.mokakbob.auth.domain.EmailVerifyCodeStore;
 import com.mokakbob.auth.util.RandomNumberGenerator;
 import java.time.Duration;
 import java.util.Objects;
@@ -33,10 +34,10 @@ public class EmailAuthService {
 
     public void checkEmailCode(String email, String code) {
         String redisMemberCode = codeStore.getCode(email)
-                .orElseThrow(() -> new DomainException(MemberErrorCode.NOT_EXIST_MAIL_CODE));
+                .orElseThrow(() -> new ApiException(AuthApiErrorCode.NOT_EXIST_MAIL_CODE));
 
         if (!Objects.equals(redisMemberCode, code)) {
-            throw new DomainException(MemberErrorCode.NOT_MATCH_MAIL_CODE);
+            throw new ApiException(AuthApiErrorCode.NOT_MATCH_MAIL_CODE);
         }
 
         codeStore.deleteCode(email);
@@ -44,7 +45,7 @@ public class EmailAuthService {
 
     private void checkCoolDown(String email) {
         if (codeStore.hasCode(email)) {
-            throw new DomainException(MemberErrorCode.TOO_MANY_REQUEST);
+            throw new ApiException(AuthApiErrorCode.TOO_MANY_REQUEST);
         }
     }
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/service/TokenProvider.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/service/TokenProvider.java
@@ -1,0 +1,6 @@
+package com.mokakbob.auth.service;
+
+public interface TokenProvider {
+    String create(Long memberId);
+    Long extractMemberId(String token);
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/common/exception/exceptions/ApiErrorCode.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/common/exception/exceptions/ApiErrorCode.java
@@ -1,0 +1,10 @@
+package com.mokakbob.common.exception.exceptions;
+
+public interface ApiErrorCode {
+
+    int httpStatus();
+
+    String customCode();
+
+    String message();
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/common/exception/exceptions/ApiException.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/common/exception/exceptions/ApiException.java
@@ -1,0 +1,15 @@
+package com.mokakbob.common.exception.exceptions;
+
+public class ApiException extends RuntimeException {
+
+    private final ApiErrorCode errorCode;
+
+    public ApiException(ApiErrorCode errorCode) {
+        super(errorCode.customCode() + ": " + errorCode.message());
+        this.errorCode = errorCode;
+    }
+
+    public ApiErrorCode apiErrorCode() {
+        return errorCode;
+    }
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/common/exception/handler/ApiExceptionHandler.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/common/exception/handler/ApiExceptionHandler.java
@@ -1,0 +1,25 @@
+package com.mokakbob.common.exception.handler;
+
+import com.mokakbob.common.exception.exceptions.ApiErrorCode;
+import com.mokakbob.common.exception.exceptions.ApiException;
+import com.mokakbob.common.exception.handler.response.CustomErrorResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ApiExceptionHandler {
+
+    @ExceptionHandler(ApiException.class)
+    public ResponseEntity<CustomErrorResponse> handleException(ApiException e) {
+        ApiErrorCode baseErrorCode = e.apiErrorCode();
+
+        CustomErrorResponse response = new CustomErrorResponse(
+                baseErrorCode.customCode(),
+                baseErrorCode.message()
+        );
+
+        return ResponseEntity.status(baseErrorCode.httpStatus())
+                .body(response);
+    }
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/common/exception/handler/DomainExceptionHandler.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/common/exception/handler/DomainExceptionHandler.java
@@ -1,9 +1,9 @@
-package com.mokakbob.exception.handler;
+package com.mokakbob.common.exception.handler;
 
 
 import com.mokakbob.common.exception.DomainErrorCode;
 import com.mokakbob.common.exception.DomainException;
-import com.mokakbob.exception.handler.response.DomainErrorResponse;
+import com.mokakbob.common.exception.handler.response.CustomErrorResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -12,10 +12,10 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class DomainExceptionHandler {
 
     @ExceptionHandler(DomainException.class)
-    public ResponseEntity<DomainErrorResponse> handleException(DomainException e) {
+    public ResponseEntity<CustomErrorResponse> handleException(DomainException e) {
         DomainErrorCode baseErrorCode = e.domainErrorCode();
 
-        DomainErrorResponse response = new DomainErrorResponse(
+        CustomErrorResponse response = new CustomErrorResponse(
                 baseErrorCode.customCode(),
                 baseErrorCode.message()
         );

--- a/mokakbob-api/src/main/java/com/mokakbob/common/exception/handler/GlobalExceptionHandler.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/common/exception/handler/GlobalExceptionHandler.java
@@ -1,6 +1,6 @@
-package com.mokakbob.exception.handler;
+package com.mokakbob.common.exception.handler;
 
-import com.mokakbob.exception.handler.response.ValidateErrorResponse;
+import com.mokakbob.common.exception.handler.response.ValidateErrorResponse;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;

--- a/mokakbob-api/src/main/java/com/mokakbob/common/exception/handler/response/CustomErrorResponse.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/common/exception/handler/response/CustomErrorResponse.java
@@ -1,0 +1,7 @@
+package com.mokakbob.common.exception.handler.response;
+
+public record CustomErrorResponse(
+        String customCode,
+        String message
+) {
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/common/exception/handler/response/ValidateErrorResponse.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/common/exception/handler/response/ValidateErrorResponse.java
@@ -1,4 +1,4 @@
-package com.mokakbob.exception.handler.response;
+package com.mokakbob.common.exception.handler.response;
 
 import java.util.List;
 

--- a/mokakbob-api/src/main/java/com/mokakbob/exception/handler/response/DomainErrorResponse.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/exception/handler/response/DomainErrorResponse.java
@@ -1,7 +1,0 @@
-package com.mokakbob.exception.handler.response;
-
-public record DomainErrorResponse(
-        String customCode,
-        String message
-) {
-}

--- a/mokakbob-api/src/test/java/com/mokakbob/auth/infrastructure/SmtpEmailSenderTest.java
+++ b/mokakbob-api/src/test/java/com/mokakbob/auth/infrastructure/SmtpEmailSenderTest.java
@@ -6,7 +6,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-import com.mokakbob.domain.member.repository.EmailVerifyCodeStore;
+import com.mokakbob.auth.domain.EmailVerifyCodeStore;
 import org.junit.jupiter.api.Test;
 import org.springframework.mail.MailException;
 import org.springframework.mail.SimpleMailMessage;

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/member/exception/MemberErrorCode.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/member/exception/MemberErrorCode.java
@@ -3,10 +3,6 @@ package com.mokakbob.domain.member.exception;
 import com.mokakbob.common.exception.DomainErrorCode;
 
 public enum MemberErrorCode implements DomainErrorCode {
-    // auth mail exception
-    NOT_MATCH_MAIL_CODE(400, "E001", "인증 코드가 일치하지 않습니다."),
-    TOO_MANY_REQUEST(400, "E002", "잠시 후 요청해주세요."),
-    NOT_EXIST_MAIL_CODE(404, "E003", "코드 값이 존재하지 않습니다.")
     ;
 
     private final int httpStatus;

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/member/service/MemberService.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/member/service/MemberService.java
@@ -1,4 +1,4 @@
-package com.mokakbob.domain.member.service.member;
+package com.mokakbob.domain.member.service;
 
 import org.springframework.stereotype.Service;
 


### PR DESCRIPTION
## 관련 이슈 번호
#11 closed

## 작업내용 25.07.22

* JWT 도메인 로직 구현하였습니다.

### jjwt 라이브러리를 사용한 JWT 도메인 로직 구현

* `TokenProvider`
  * `TokenProvider`는 도메인 계층에 인터페이스로 구현하였고, 실제 구현체(`JwtTokenProvider`)는 인프라스트럭처 계층에 둬서 JWT 라이브러리 의존을 분리하였습니다.
  * 해당 인터페이스를 도메인 계층에 둔 이유는, 토큰 생성 및 검증이라는 인증 관련 로직이 도메인 규칙에 해당된다고 판단했습니다.

* jjwt 라이브러리를 사용한 이유
  * Auth0 라이브러리와 고민하였는데, Auth0은 외부에서 발급된 토큰을 검증하고 관리하는데 더 특화되어 있다는 것을 알 수 있었습니다.
  * 하지만 제 서비스에서는 외부 토큰을 이용할 필요가 없기에, 비교적 커스터마이징이 쉬운 jjwt 라이브러리를 사용하였습니다.

* secretKey
  * `hmacShaKeyFor()` 메서드를 사용하여 키를 생성해주었고, 최소 32비트를 필요로 하기에 그에 맞게 키 값 설정해서(application.properties) 주입해주었습니다.

* 암호화 알고리즘
  * `대칭키(HS256)`를 사용하여 JWT 토큰 발급되도록 하였습니다.
  * 이유는, 발급 및 검증 주체가 모두 자체 서비스이기에 대칭키 알고리즘이 속도와 안정성 측면에서 더 났다고 판단했습니다.
  
* 토큰 생성 및 파싱 로직 구현하였습니다.

### 참고사항

* 로직 책임을 api 모듈로 전환하면서(email / token) api 모듈 단의 예외처리가 따로 필요하다고 생각되어 api 전용 exception 구조 정의하였습니다.