### PR TITLE
#17 [FEAT] 비밀번호 암호화 로직 및 회원가입 API 구현

### DIFF
--- a/docs/DDL.md
+++ b/docs/DDL.md
@@ -1,0 +1,11 @@
+## MemberRepository
+
+* 이메일 중복 확인 DDL
+  ~~~
+  CREATE UNIQUE INDEX idx_member_email ON member (email);
+  ~~~
+  
+* 닉네임 중복 확인 DDL
+  ~~~
+  CREATE UNIQUE INDEX idx_member_nickname ON member (nickname);
+  ~~~

--- a/docs/DDL.md
+++ b/docs/DDL.md
@@ -1,11 +1,41 @@
+## Member 최초 스키마 DDL
+~~~
+CREATE TABLE member (
+id BIGINT AUTO_INCREMENT PRIMARY KEY,
+
+    email VARCHAR(255) NOT NULL UNIQUE,
+    
+    password_enc VARCHAR(255),  -- 소셜 로그인 사용자는 NULL 가능
+    
+    nickname VARCHAR(255) NOT NULL UNIQUE,
+    
+    profile_image VARCHAR(512), -- 프로필 이미지는 선택 사항
+    
+    preference VARCHAR(50) NOT NULL, -- EnumType.STRING으로 저장됨
+    
+    score INT NOT NULL DEFAULT 50,  -- 기본값 50
+    
+    deposit_point INT NOT NULL DEFAULT 2000, -- 기본값 2000
+    
+    created_at DATETIME NOT NULL,  -- BaseEntity 상속 필드
+    updated_at DATETIME NOT NULL   -- BaseEntity 상속 필드
+);
+~~~
+
 ## MemberRepository
 
 * 이메일 중복 확인 DDL
   ~~~
   CREATE UNIQUE INDEX idx_member_email ON member (email);
   ~~~
+  * 이메일 인덱스는 이미 생성되어있음.
+  
+
   
 * 닉네임 중복 확인 DDL
   ~~~
   CREATE UNIQUE INDEX idx_member_nickname ON member (nickname);
   ~~~
+  * 닉네임 인덱스는 이미 생성되어있음.
+
+---

--- a/mokakbob-api/build.gradle
+++ b/mokakbob-api/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5")
 
     // passwordEnc
-    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.security:spring-security-crypto'
 }
 
 springBoot {

--- a/mokakbob-api/build.gradle
+++ b/mokakbob-api/build.gradle
@@ -23,6 +23,9 @@ dependencies {
     implementation("io.jsonwebtoken:jjwt-api:0.11.5")
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.5")
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.5")
+
+    // passwordEnc
+    implementation 'org.springframework.boot:spring-boot-starter-security'
 }
 
 springBoot {

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/config/SecurityConfig.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/config/SecurityConfig.java
@@ -1,0 +1,15 @@
+package com.mokakbob.auth.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/controller/AuthController.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/controller/AuthController.java
@@ -4,6 +4,7 @@ import com.mokakbob.auth.controller.request.SignUpRequest;
 import com.mokakbob.auth.controller.response.SignUpResponse;
 import com.mokakbob.auth.service.AuthService;
 import com.mokakbob.common.path.auth.AuthApiPath;
+import com.mokakbob.domain.member.domain.Member;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -19,7 +20,13 @@ public class AuthController {
 
     @PostMapping(AuthApiPath.SIGN_UP)
     public ResponseEntity<SignUpResponse> signUp(@Valid @RequestBody SignUpRequest request) {
-        return ResponseEntity.ok()
-                .build();
+        Member member = authService.signUp(
+                request.email(),
+                request.password(),
+                request.nickName(),
+                request.preference()
+        );
+
+        return ResponseEntity.ok(new SignUpResponse(member.getEmail(), member.getNickname()));
     }
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/controller/AuthController.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/controller/AuthController.java
@@ -1,0 +1,25 @@
+package com.mokakbob.auth.controller;
+
+import com.mokakbob.auth.controller.request.SignUpRequest;
+import com.mokakbob.auth.controller.response.SignUpResponse;
+import com.mokakbob.auth.service.AuthService;
+import com.mokakbob.common.path.auth.AuthApiPath;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping(AuthApiPath.SIGN_UP)
+    public ResponseEntity<SignUpResponse> signUp(@Valid @RequestBody SignUpRequest request) {
+        return ResponseEntity.ok()
+                .build();
+    }
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/controller/AuthEmailController.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/controller/AuthEmailController.java
@@ -1,7 +1,7 @@
 package com.mokakbob.auth.controller;
 
 import com.mokakbob.auth.controller.request.EmailCodeRequest;
-import com.mokakbob.common.path.EmailApiPath;
+import com.mokakbob.common.path.auth.EmailApiPath;
 import com.mokakbob.auth.service.EmailAuthService;
 import com.mokakbob.auth.controller.request.EmailSendRequest;
 import jakarta.validation.Valid;

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/controller/request/SignUpRequest.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/controller/request/SignUpRequest.java
@@ -1,9 +1,10 @@
 package com.mokakbob.auth.controller.request;
 
+import com.mokakbob.domain.member.domain.vo.MemberPreference;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import org.springframework.web.multipart.MultipartFile;
 
 public record SignUpRequest(
         @Email
@@ -18,9 +19,7 @@ public record SignUpRequest(
         @Size(max = 20)
         String nickName,
 
-        @NotBlank
-        String preference,
-
-        MultipartFile profileImage
+        @NotNull
+        MemberPreference preference
 ) {
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/controller/response/SignUpResponse.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/controller/response/SignUpResponse.java
@@ -1,4 +1,7 @@
 package com.mokakbob.auth.controller.response;
 
-public record SignUpResponse() {
+public record SignUpResponse(
+        String email,
+        String nickName
+) {
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/controller/response/SignUpResponse.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/controller/response/SignUpResponse.java
@@ -1,0 +1,4 @@
+package com.mokakbob.auth.controller.response;
+
+public record SignUpResponse() {
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/service/AuthService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/service/AuthService.java
@@ -1,7 +1,10 @@
 package com.mokakbob.auth.service;
 
+import com.mokakbob.domain.member.domain.Member;
+import com.mokakbob.domain.member.domain.vo.MemberPreference;
 import com.mokakbob.domain.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -11,6 +14,16 @@ import org.springframework.transaction.annotation.Transactional;
 public class AuthService {
 
     private final MemberService memberService;
+    private final PasswordEncoder passwordEncoder;
 
+    public Member signUp(String email, String password, String nickName, MemberPreference preference) {
+        String passwordEnc = passwordEncoder.encode(password);
 
+        return memberService.createMember(
+                email,
+                passwordEnc,
+                nickName,
+                preference
+        );
+    }
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/service/AuthService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/service/AuthService.java
@@ -1,0 +1,7 @@
+package com.mokakbob.auth.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class AuthService {
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/service/AuthService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/service/AuthService.java
@@ -6,17 +6,14 @@ import com.mokakbob.domain.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class AuthService {
 
     private final MemberService memberService;
     private final PasswordEncoder passwordEncoder;
 
-    @Transactional
     public Member signUp(String email, String password, String nickName, MemberPreference preference) {
         String passwordEnc = passwordEncoder.encode(password);
 

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/service/AuthService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/service/AuthService.java
@@ -16,6 +16,7 @@ public class AuthService {
     private final MemberService memberService;
     private final PasswordEncoder passwordEncoder;
 
+    @Transactional
     public Member signUp(String email, String password, String nickName, MemberPreference preference) {
         String passwordEnc = passwordEncoder.encode(password);
 

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/service/AuthService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/service/AuthService.java
@@ -1,7 +1,16 @@
 package com.mokakbob.auth.service;
 
+import com.mokakbob.domain.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
 public class AuthService {
+
+    private final MemberService memberService;
+
+
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/common/path/auth/AuthApiPath.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/common/path/auth/AuthApiPath.java
@@ -1,0 +1,10 @@
+package com.mokakbob.common.path.auth;
+
+import com.mokakbob.common.path.ApiVersion;
+
+public class AuthApiPath {
+
+    private static final String BASE = ApiVersion.V1 + "/auth";
+
+    public static final String SIGN_UP = BASE + "/signUp";
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/common/path/auth/EmailApiPath.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/common/path/auth/EmailApiPath.java
@@ -1,4 +1,6 @@
-package com.mokakbob.common.path;
+package com.mokakbob.common.path.auth;
+
+import com.mokakbob.common.path.ApiVersion;
 
 public class EmailApiPath {
 

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/member/exception/MemberErrorCode.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/member/exception/MemberErrorCode.java
@@ -3,6 +3,8 @@ package com.mokakbob.domain.member.exception;
 import com.mokakbob.common.exception.DomainErrorCode;
 
 public enum MemberErrorCode implements DomainErrorCode {
+    DUPLICATE_EMAIL(409, "M001", "중복되는 이메일입니다."),
+    DUPLICATE_NICKNAME(409, "M002", "중복되는 이메일입니다.")
     ;
 
     private final int httpStatus;

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/member/repository/MemberRepository.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/member/repository/MemberRepository.java
@@ -6,4 +6,8 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    boolean existsByEmail(String email);
+
+    boolean existsByNickname(String nickName);
 }

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/member/service/MemberService.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/member/service/MemberService.java
@@ -10,7 +10,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class MemberService {
 
@@ -19,6 +18,7 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
 
+    @Transactional
     public Member createMember(String email, String passwordEnc, String nickName, MemberPreference preference) {
         validateDuplicateEmail(email);
         validateDuplicateNickName(nickName);

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/member/service/MemberService.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/member/service/MemberService.java
@@ -1,7 +1,28 @@
 package com.mokakbob.domain.member.service;
 
+import com.mokakbob.common.exception.DomainException;
+import com.mokakbob.domain.member.exception.MemberErrorCode;
+import com.mokakbob.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
 public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    private void validateDuplicateEmail(String email) {
+        if (memberRepository.existsByEmail(email)) {
+            throw new DomainException(MemberErrorCode.DUPLICATE_EMAIL);
+        }
+    }
+
+    private void validateDuplicateNickName(String nickName) {
+        if (memberRepository.existsByNickname(nickName)) {
+            throw new DomainException(MemberErrorCode.DUPLICATE_NICKNAME);
+        }
+    }
 }

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/member/service/MemberService.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/member/service/MemberService.java
@@ -1,6 +1,8 @@
 package com.mokakbob.domain.member.service;
 
 import com.mokakbob.common.exception.DomainException;
+import com.mokakbob.domain.member.domain.Member;
+import com.mokakbob.domain.member.domain.vo.MemberPreference;
 import com.mokakbob.domain.member.exception.MemberErrorCode;
 import com.mokakbob.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -12,7 +14,26 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class MemberService {
 
+    private static final int DEFAULT_SCORE = 50;
+    private static final int DEFAULT_POINT = 2000;
+
     private final MemberRepository memberRepository;
+
+    public Member createMember(String email, String passwordEnc, String nickName, MemberPreference preference) {
+        validateDuplicateEmail(email);
+        validateDuplicateNickName(nickName);
+
+        Member member = Member.builder()
+                .email(email)
+                .passwordEnc(passwordEnc)
+                .nickname(nickName)
+                .preference(preference)
+                .score(DEFAULT_SCORE)
+                .depositPoint(DEFAULT_POINT)
+                .build();
+
+        return memberRepository.save(member);
+    }
 
     private void validateDuplicateEmail(String email) {
         if (memberRepository.existsByEmail(email)) {


### PR DESCRIPTION
## 관련 이슈 번호
#17 closed

## 작업내용 25.07.30
* 비밀번호 암호화 로직 작성 및 회원가입 API 구현

### 비밀번호 암호화 로직 
* `org.springframework.security:spring-security-crypto`
  * 스프링 시큐리티 라이브러리를 사용하지 않고 암호화 관련 라이브러리만 사용하기 위해 해당 라이브러리를 사용하였습니다.
  * `BCrypt` 매서드 사용하였습니다.

### 책임 분리
* 이메일 중복처리, 회원 정보 저장 같이 repository 와 밀접하게 관련있는 로직들은 domain 모듈의 Service 계층에서 로직 구현하였습니다.
* 비밀번호 암호화같은 로직은 domain 모듈과 상관이 없다고 판단하여, api 모듈 단의 Service 계층에서 로직 구현하였습니다.
