### PR TITLE
#20 [FEAT] 로그인 API 구현 및 JWT Token 발급

### DIFF
--- a/mokakbob-api/src/main/java/com/mokakbob/auth/controller/AuthController.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/controller/AuthController.java
@@ -1,7 +1,10 @@
 package com.mokakbob.auth.controller;
 
+import com.mokakbob.auth.controller.request.LoginRequest;
 import com.mokakbob.auth.controller.request.SignUpRequest;
+import com.mokakbob.auth.controller.response.LoginResponse;
 import com.mokakbob.auth.controller.response.SignUpResponse;
+import com.mokakbob.auth.infrastructure.JwtTokenProvider;
 import com.mokakbob.auth.service.AuthService;
 import com.mokakbob.common.path.auth.AuthApiPath;
 import com.mokakbob.domain.member.domain.Member;
@@ -17,6 +20,21 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final AuthService authService;
+    private final JwtTokenProvider tokenProvider;
+
+    @PostMapping(AuthApiPath.LOGIN)
+    public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
+        Member member = authService.login(request.email(), request.password());
+        String token = tokenProvider.create(member.getId());
+
+        return ResponseEntity.ok(new LoginResponse(
+                token,
+                member.getId(),
+                member.getEmail(),
+                member.getNickname(),
+                member.getProfileImage()
+        ));
+    }
 
     @PostMapping(AuthApiPath.SIGN_UP)
     public ResponseEntity<SignUpResponse> signUp(@Valid @RequestBody SignUpRequest request) {

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/controller/request/LoginRequest.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/controller/request/LoginRequest.java
@@ -1,0 +1,14 @@
+package com.mokakbob.auth.controller.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+        @Email
+        @NotBlank
+        String email,
+
+        @NotBlank
+        String password
+) {
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/controller/response/LoginResponse.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/controller/response/LoginResponse.java
@@ -1,0 +1,10 @@
+package com.mokakbob.auth.controller.response;
+
+public record LoginResponse(
+        String token,
+        Long id,
+        String email,
+        String nickname,
+        String profileImageUrl
+) {
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/exception/AuthApiErrorCode.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/exception/AuthApiErrorCode.java
@@ -11,7 +11,10 @@ public enum AuthApiErrorCode implements ApiErrorCode {
     // token exception
     TOKEN_EXPIRED(401, "JWT001", "토큰이 만료되었습니다."),
     TOKEN_INVALID_SIGNATURE(401, "JWT002", "토큰 서명이 유효하지 않습니다."),
-    TOKEN_INVALID(401, "JWT003", "유효하지 않은 토큰입니다.")
+    TOKEN_INVALID(401, "JWT003", "유효하지 않은 토큰입니다."),
+
+    // auth login exception
+    NOT_MATCH_PASSWORD(401, "L001", "비밀번호가 일치하지 않습니다.")
     ;
 
     private final int httpStatus;

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/service/AuthService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/service/AuthService.java
@@ -1,5 +1,7 @@
 package com.mokakbob.auth.service;
 
+import com.mokakbob.auth.exception.AuthApiErrorCode;
+import com.mokakbob.common.exception.exceptions.ApiException;
 import com.mokakbob.domain.member.domain.Member;
 import com.mokakbob.domain.member.domain.vo.MemberPreference;
 import com.mokakbob.domain.member.service.MemberService;
@@ -13,6 +15,16 @@ public class AuthService {
 
     private final MemberService memberService;
     private final PasswordEncoder passwordEncoder;
+
+    public Member login(String email, String password) {
+        Member member = memberService.findMemberByEmail(email);
+
+        if (!passwordEncoder.matches(password, member.getPasswordEnc())) {
+            throw new ApiException(AuthApiErrorCode.NOT_MATCH_PASSWORD);
+        }
+
+        return member;
+    }
 
     public Member signUp(String email, String password, String nickName, MemberPreference preference) {
         String passwordEnc = passwordEncoder.encode(password);

--- a/mokakbob-api/src/main/java/com/mokakbob/common/path/auth/AuthApiPath.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/common/path/auth/AuthApiPath.java
@@ -7,4 +7,5 @@ public class AuthApiPath {
     private static final String BASE = ApiVersion.V1 + "/auth";
 
     public static final String SIGN_UP = BASE + "/signUp";
+    public static final String LOGIN = BASE + "/login";
 }

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/member/exception/MemberErrorCode.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/member/exception/MemberErrorCode.java
@@ -4,7 +4,8 @@ import com.mokakbob.common.exception.DomainErrorCode;
 
 public enum MemberErrorCode implements DomainErrorCode {
     DUPLICATE_EMAIL(409, "M001", "중복되는 이메일입니다."),
-    DUPLICATE_NICKNAME(409, "M002", "중복되는 이메일입니다.")
+    DUPLICATE_NICKNAME(409, "M002", "중복되는 이메일입니다."),
+    NOT_FOUND_MEMBER_BY_EMAIL(404, "M003", "이메일에 해당하는 유저 정보가 없습니다.")
     ;
 
     private final int httpStatus;

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/member/repository/MemberRepository.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/member/repository/MemberRepository.java
@@ -1,6 +1,7 @@
 package com.mokakbob.domain.member.repository;
 
 import com.mokakbob.domain.member.domain.Member;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -10,4 +11,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByEmail(String email);
 
     boolean existsByNickname(String nickName);
+
+    Optional<Member> findByEmail(String email);
 }

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/member/service/MemberService.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/member/service/MemberService.java
@@ -18,6 +18,11 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
 
+    public Member findMemberByEmail(String email) {
+        return memberRepository.findByEmail(email)
+                .orElseThrow(() -> new DomainException(MemberErrorCode.NOT_FOUND_MEMBER_BY_EMAIL));
+    }
+
     @Transactional
     public Member createMember(String email, String passwordEnc, String nickName, MemberPreference preference) {
         validateDuplicateEmail(email);


### PR DESCRIPTION
## 관련 이슈 번호
#20 closed

## 작업 내용 25.07.30

### 로그인 API 구현
* 이메일로 member 조회 후, 비밀번호 matches 메서드를 통해 비밀번호 일치 여부 검증하였습니다.
* 책임 분리를 위해 이메일 member 조회는 domain 모듈에서 / 비밀번호 일치 여부는 api 모듈에서 구현하였습니다.

### 참고 사항
* loginResponse
  * postUrlPath 필드의 경우, 현재 null 값을 반환하는데, 이미지 업로드 기능 구현 끝난 후에 Default_Url(이미지 없다면 기본 이미지) 반환하도록 수정할 계획입니다.

* refreshToken 기능 구현 예정입니다. 이에 따라 변동사항 있을 것 같습니다.