### PR TITLE
#22 [FEAT] Refresh Token 로직 구현 및 재발급 API 구현

### DIFF
--- a/mokakbob-api/src/main/java/com/mokakbob/auth/controller/AuthController.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/controller/AuthController.java
@@ -25,7 +25,7 @@ public class AuthController {
     @PostMapping(AuthApiPath.LOGIN)
     public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
         Member member = authService.login(request.email(), request.password());
-        String token = tokenProvider.create(member.getId());
+        String token = tokenProvider.createAccessToken(member.getId());
 
         return ResponseEntity.ok(new LoginResponse(
                 token,

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/controller/AuthController.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/controller/AuthController.java
@@ -13,6 +13,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -34,13 +36,17 @@ public class AuthController {
         String accessToken = tokenService.createAccessToken(member.getId());
         tokenService.createRefreshToken(member.getId(), response);
 
-        return ResponseEntity.ok(new LoginResponse(
-                accessToken,
-                member.getId(),
-                member.getEmail(),
-                member.getNickname(),
-                member.getProfileImage()
-        ));
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.set("Authorization", "Bearer " + accessToken);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .headers(httpHeaders)
+                .body(new LoginResponse(
+                        member.getId(),
+                        member.getEmail(),
+                        member.getNickname(),
+                        member.getProfileImage()
+                ));
     }
 
     @PostMapping(AuthApiPath.SIGN_UP)

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/controller/AuthController.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/controller/AuthController.java
@@ -4,10 +4,12 @@ import com.mokakbob.auth.controller.request.LoginRequest;
 import com.mokakbob.auth.controller.request.SignUpRequest;
 import com.mokakbob.auth.controller.response.LoginResponse;
 import com.mokakbob.auth.controller.response.SignUpResponse;
+import com.mokakbob.auth.controller.response.TokenReissueResponse;
 import com.mokakbob.auth.service.AuthService;
 import com.mokakbob.auth.service.TokenService;
 import com.mokakbob.common.path.auth.AuthApiPath;
 import com.mokakbob.domain.member.domain.Member;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -30,8 +32,7 @@ public class AuthController {
     ) {
         Member member = authService.login(request.email(), request.password());
         String accessToken = tokenService.createAccessToken(member.getId());
-        String refreshToken = tokenService.createRefreshToken(member.getId());
-        tokenService.addRefreshTokenToCookie(response, refreshToken);
+        tokenService.createRefreshToken(member.getId(), response);
 
         return ResponseEntity.ok(new LoginResponse(
                 accessToken,
@@ -52,5 +53,15 @@ public class AuthController {
         );
 
         return ResponseEntity.ok(new SignUpResponse(member.getEmail(), member.getNickname()));
+    }
+
+    @PostMapping(AuthApiPath.REISSUE)
+    public ResponseEntity<TokenReissueResponse> reissue(
+            HttpServletRequest request,
+            HttpServletResponse response
+    ) {
+        String newToken = tokenService.reissue(response, request);
+
+        return ResponseEntity.ok(new TokenReissueResponse(newToken));
     }
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/controller/AuthController.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/controller/AuthController.java
@@ -4,10 +4,11 @@ import com.mokakbob.auth.controller.request.LoginRequest;
 import com.mokakbob.auth.controller.request.SignUpRequest;
 import com.mokakbob.auth.controller.response.LoginResponse;
 import com.mokakbob.auth.controller.response.SignUpResponse;
-import com.mokakbob.auth.infrastructure.JwtTokenProvider;
 import com.mokakbob.auth.service.AuthService;
+import com.mokakbob.auth.service.TokenService;
 import com.mokakbob.common.path.auth.AuthApiPath;
 import com.mokakbob.domain.member.domain.Member;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -20,15 +21,20 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final AuthService authService;
-    private final JwtTokenProvider tokenProvider;
+    private final TokenService tokenService;
 
     @PostMapping(AuthApiPath.LOGIN)
-    public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
+    public ResponseEntity<LoginResponse> login(
+            @Valid @RequestBody LoginRequest request,
+            HttpServletResponse response
+    ) {
         Member member = authService.login(request.email(), request.password());
-        String token = tokenProvider.createAccessToken(member.getId());
+        String accessToken = tokenService.createAccessToken(member.getId());
+        String refreshToken = tokenService.createRefreshToken(member.getId());
+        tokenService.addRefreshTokenToCookie(response, refreshToken);
 
         return ResponseEntity.ok(new LoginResponse(
-                token,
+                accessToken,
                 member.getId(),
                 member.getEmail(),
                 member.getNickname(),

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/controller/response/LoginResponse.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/controller/response/LoginResponse.java
@@ -1,7 +1,6 @@
 package com.mokakbob.auth.controller.response;
 
 public record LoginResponse(
-        String accessToken,
         Long id,
         String email,
         String nickname,

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/controller/response/LoginResponse.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/controller/response/LoginResponse.java
@@ -1,7 +1,7 @@
 package com.mokakbob.auth.controller.response;
 
 public record LoginResponse(
-        String token,
+        String accessToken,
         Long id,
         String email,
         String nickname,

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/controller/response/TokenReissueResponse.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/controller/response/TokenReissueResponse.java
@@ -1,0 +1,6 @@
+package com.mokakbob.auth.controller.response;
+
+public record TokenReissueResponse(
+        String reIssuedToken
+) {
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/domain/RefreshTokenStore.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/domain/RefreshTokenStore.java
@@ -1,0 +1,12 @@
+package com.mokakbob.auth.domain;
+
+import java.time.Duration;
+import java.util.Optional;
+
+public interface RefreshTokenStore {
+
+    void save(Long memberId, String refreshToken, Duration ttl);
+    Optional<String> get(Long memberId);
+    void delete(Long memberId);
+    boolean exists(Long memberId);
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/domain/TokenProvider.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/domain/TokenProvider.java
@@ -4,4 +4,5 @@ public interface TokenProvider {
     String createAccessToken(Long memberId);
     String createRefreshToken(Long memberId);
     Long extractMemberId(String token);
+    boolean isAccessTokenExpired(String token);
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/domain/TokenProvider.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/domain/TokenProvider.java
@@ -1,6 +1,7 @@
 package com.mokakbob.auth.domain;
 
 public interface TokenProvider {
-    String create(Long memberId);
+    String createAccessToken(Long memberId);
+    String createRefreshToken(Long memberId);
     Long extractMemberId(String token);
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/exception/AuthApiErrorCode.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/exception/AuthApiErrorCode.java
@@ -12,6 +12,7 @@ public enum AuthApiErrorCode implements ApiErrorCode {
     TOKEN_EXPIRED(401, "JWT001", "토큰이 만료되었습니다."),
     TOKEN_INVALID_SIGNATURE(401, "JWT002", "토큰 서명이 유효하지 않습니다."),
     TOKEN_INVALID(401, "JWT003", "유효하지 않은 토큰입니다."),
+    TOKEN_NOT_FOUND(404, "JWT004", "토큰을 찾을 수 없습니다."),
 
     // auth login exception
     NOT_MATCH_PASSWORD(401, "L001", "비밀번호가 일치하지 않습니다.")

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/exception/AuthApiErrorCode.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/exception/AuthApiErrorCode.java
@@ -13,6 +13,7 @@ public enum AuthApiErrorCode implements ApiErrorCode {
     TOKEN_INVALID_SIGNATURE(401, "JWT002", "토큰 서명이 유효하지 않습니다."),
     TOKEN_INVALID(401, "JWT003", "유효하지 않은 토큰입니다."),
     TOKEN_NOT_FOUND(404, "JWT004", "토큰을 찾을 수 없습니다."),
+    TOKEN_NOT_EXPIRED(400, "JWT005", "accessToken 이 아직 유효합니다."),
 
     // auth login exception
     NOT_MATCH_PASSWORD(401, "L001", "비밀번호가 일치하지 않습니다.")

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/infrastructure/JwtTokenProvider.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/infrastructure/JwtTokenProvider.java
@@ -19,32 +19,32 @@ import org.springframework.stereotype.Component;
 public class JwtTokenProvider implements TokenProvider {
 
     private final Key secretKey;
-    private final long accessExpirationPeriod;
-    private final long refreshExpirationPeriod;
+    private final long accessExpirationPeriodMillis;
+    private final long refreshExpirationPeriodMillis;
 
     public JwtTokenProvider(
             @Value("${jwt.secret}") String secretKey,
-            @Value("${jwt.access.expiration-period}") long accessExpirationPeriod,
-            @Value("${jwt.refresh.expiration-period}") long refreshExpirationPeriod
+            @Value("${jwt.access.expiration-period}") long accessExpirationPeriodMillis,
+            @Value("${jwt.refresh.expiration-period}") long refreshExpirationPeriodMillis
     ) {
         this.secretKey = Keys.hmacShaKeyFor(secretKey.getBytes());
-        this.accessExpirationPeriod = accessExpirationPeriod;
-        this.refreshExpirationPeriod = refreshExpirationPeriod;
+        this.accessExpirationPeriodMillis = accessExpirationPeriodMillis;
+        this.refreshExpirationPeriodMillis = refreshExpirationPeriodMillis;
     }
 
     @Override
     public String createAccessToken(Long memberId) {
-        return create(memberId, accessExpirationPeriod);
+        return create(memberId, accessExpirationPeriodMillis);
     }
 
     @Override
     public String createRefreshToken(Long memberId) {
-        return create(memberId, refreshExpirationPeriod);
+        return create(memberId, refreshExpirationPeriodMillis);
     }
 
-    public String create(Long memberId, long expirationPeriod) {
+    public String create(Long memberId, long expirationPeriodMillis) {
         Date now = new Date();
-        Date expire = new Date(now.getTime() + expirationPeriod);
+        Date expire = new Date(now.getTime() + expirationPeriodMillis);
 
         return Jwts.builder()
                 .setSubject(String.valueOf(memberId))

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/infrastructure/JwtTokenProvider.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/infrastructure/JwtTokenProvider.java
@@ -19,18 +19,30 @@ import org.springframework.stereotype.Component;
 public class JwtTokenProvider implements TokenProvider {
 
     private final Key secretKey;
-    private final long expirationPeriod;
+    private final long accessExpirationPeriod;
+    private final long refreshExpirationPeriod;
 
     public JwtTokenProvider(
             @Value("${jwt.secret}") String secretKey,
-            @Value("${jwt.expiration-period}") long expirationPeriod
+            @Value("${jwt.access.expiration-period}") long accessExpirationPeriod,
+            @Value("${jwt.refresh.expiration-period}") long refreshExpirationPeriod
     ) {
         this.secretKey = Keys.hmacShaKeyFor(secretKey.getBytes());
-        this.expirationPeriod = expirationPeriod;
+        this.accessExpirationPeriod = accessExpirationPeriod;
+        this.refreshExpirationPeriod = refreshExpirationPeriod;
     }
 
     @Override
-    public String create(Long memberId) {
+    public String createAccessToken(Long memberId) {
+        return create(memberId, accessExpirationPeriod);
+    }
+
+    @Override
+    public String createRefreshToken(Long memberId) {
+        return create(memberId, refreshExpirationPeriod);
+    }
+
+    public String create(Long memberId, long expirationPeriod) {
         Date now = new Date();
         Date expire = new Date(now.getTime() + expirationPeriod);
 

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/infrastructure/JwtTokenProvider.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/infrastructure/JwtTokenProvider.java
@@ -60,6 +60,18 @@ public class JwtTokenProvider implements TokenProvider {
         return Long.valueOf(claims.getSubject());
     }
 
+    @Override
+    public boolean isAccessTokenExpired(String token) {
+        try {
+            Claims claims = parseToken(token);
+
+            return claims.getExpiration()
+                    .before(new Date());
+        } catch (ExpiredJwtException e) {
+            return true;
+        }
+    }
+
     private Claims parseToken(String token) {
         try {
             return Jwts.parserBuilder()

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/infrastructure/RedisRefreshTokenStore.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/infrastructure/RedisRefreshTokenStore.java
@@ -1,0 +1,44 @@
+package com.mokakbob.auth.infrastructure;
+
+import com.mokakbob.auth.domain.RefreshTokenStore;
+import java.time.Duration;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisRefreshTokenStore implements RefreshTokenStore {
+
+    private static final String TOKEN_KEY_PREFIX = "refresh:";
+
+    private final StringRedisTemplate redisTemplate;
+
+    @Override
+    public void save(Long memberId, String refreshToken, Duration ttl) {
+        redisTemplate.opsForValue()
+                .set(key(memberId), refreshToken, ttl);
+    }
+
+    @Override
+    public Optional<String> get(Long memberId) {
+        return Optional.ofNullable(redisTemplate.opsForValue()
+                .get(key(memberId)));
+    }
+
+    @Override
+    public void delete(Long memberId) {
+        redisTemplate.delete(key(memberId));
+    }
+
+    @Override
+    public boolean exists(Long memberId) {
+        return Boolean.TRUE
+                .equals(redisTemplate.hasKey(key(memberId)));
+    }
+
+    private String key(Long memberId) {
+        return TOKEN_KEY_PREFIX + memberId;
+    }
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/infrastructure/RedisRefreshTokenStore.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/infrastructure/RedisRefreshTokenStore.java
@@ -4,7 +4,7 @@ import com.mokakbob.auth.domain.RefreshTokenStore;
 import java.time.Duration;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -13,29 +13,29 @@ public class RedisRefreshTokenStore implements RefreshTokenStore {
 
     private static final String TOKEN_KEY_PREFIX = "refresh:";
 
-    private final StringRedisTemplate redisTemplate;
+    private final RedisTemplate<String, String> authRedisTemplate;
 
     @Override
     public void save(Long memberId, String refreshToken, Duration ttl) {
-        redisTemplate.opsForValue()
+        authRedisTemplate.opsForValue()
                 .set(key(memberId), refreshToken, ttl);
     }
 
     @Override
     public Optional<String> get(Long memberId) {
-        return Optional.ofNullable(redisTemplate.opsForValue()
+        return Optional.ofNullable(authRedisTemplate.opsForValue()
                 .get(key(memberId)));
     }
 
     @Override
     public void delete(Long memberId) {
-        redisTemplate.delete(key(memberId));
+        authRedisTemplate.delete(key(memberId));
     }
 
     @Override
     public boolean exists(Long memberId) {
         return Boolean.TRUE
-                .equals(redisTemplate.hasKey(key(memberId)));
+                .equals(authRedisTemplate.hasKey(key(memberId)));
     }
 
     private String key(Long memberId) {

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/service/TokenService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/service/TokenService.java
@@ -2,9 +2,14 @@ package com.mokakbob.auth.service;
 
 import com.mokakbob.auth.domain.RefreshTokenStore;
 import com.mokakbob.auth.domain.TokenProvider;
+import com.mokakbob.auth.exception.AuthApiErrorCode;
+import com.mokakbob.common.exception.exceptions.ApiException;
+import com.mokakbob.common.path.auth.AuthApiPath;
 import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.time.Duration;
+import java.util.Arrays;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -13,7 +18,6 @@ import org.springframework.stereotype.Service;
 public class TokenService {
 
     private static final String COOKIE_NAME = "refreshToken";
-    private static final int COOKIE_DURATION = 7 * 24 * 60 * 60;
     private static final Duration REFRESH_TTL = Duration.ofDays(7);
 
     private final TokenProvider tokenProvider;
@@ -23,19 +27,47 @@ public class TokenService {
         return tokenProvider.createAccessToken(memberId);
     }
 
-    public String createRefreshToken(Long memberId) {
+    public void createRefreshToken(Long memberId, HttpServletResponse response) {
         String refreshToken = tokenProvider.createRefreshToken(memberId);
         refreshTokenStore.save(memberId, refreshToken, REFRESH_TTL);
-
-        return refreshToken;
+        addRefreshTokenToCookie(response, refreshToken);
     }
 
-    public void addRefreshTokenToCookie(HttpServletResponse response, String refreshToken) {
+    private void addRefreshTokenToCookie(HttpServletResponse response, String refreshToken) {
         Cookie cookie = new Cookie(COOKIE_NAME, refreshToken);
         cookie.setHttpOnly(true);
-        cookie.setSecure(true);
-        cookie.setPath("/api/token/reissue");
-        cookie.setMaxAge(COOKIE_DURATION);
+        cookie.setSecure(false);
+        cookie.setPath(AuthApiPath.REISSUE);
+        cookie.setMaxAge((int) REFRESH_TTL.getSeconds());
         response.addCookie(cookie);
+    }
+
+    public String reissue(HttpServletResponse response, HttpServletRequest request) {
+        String refreshToken = extractRefreshTokenFromCookie(request);
+        Long memberId = tokenProvider.extractMemberId(refreshToken);
+
+        String savedToken = refreshTokenStore.get(memberId)
+                .orElseThrow(() -> new ApiException(AuthApiErrorCode.TOKEN_NOT_FOUND));
+
+        if (!savedToken.equals(refreshToken)) {
+            throw new ApiException(AuthApiErrorCode.TOKEN_INVALID);
+        }
+
+        String newAccessToken = tokenProvider.createAccessToken(memberId);
+        createRefreshToken(memberId, response);
+
+        return newAccessToken;
+    }
+
+    private String extractRefreshTokenFromCookie(HttpServletRequest request) {
+        if (request.getCookies() == null) {
+            throw new ApiException(AuthApiErrorCode.TOKEN_NOT_FOUND);
+        }
+
+        return Arrays.stream(request.getCookies())
+                .filter(cookie -> COOKIE_NAME.equals(cookie.getName()))
+                .findFirst()
+                .map(Cookie::getValue)
+                .orElseThrow(() -> new ApiException(AuthApiErrorCode.TOKEN_NOT_FOUND));
     }
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/service/TokenService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/service/TokenService.java
@@ -36,7 +36,7 @@ public class TokenService {
     private void addRefreshTokenToCookie(HttpServletResponse response, String refreshToken) {
         Cookie cookie = new Cookie(COOKIE_NAME, refreshToken);
         cookie.setHttpOnly(true);
-        cookie.setSecure(false);
+        cookie.setSecure(true);
         cookie.setPath(AuthApiPath.REISSUE);
         cookie.setMaxAge((int) REFRESH_TTL.getSeconds());
         response.addCookie(cookie);

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/service/TokenService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/service/TokenService.java
@@ -5,11 +5,11 @@ import com.mokakbob.auth.domain.TokenProvider;
 import com.mokakbob.auth.exception.AuthApiErrorCode;
 import com.mokakbob.common.exception.exceptions.ApiException;
 import com.mokakbob.common.path.auth.AuthApiPath;
+import com.mokakbob.common.util.TokenExtractor;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.time.Duration;
-import java.util.Arrays;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -22,6 +22,7 @@ public class TokenService {
 
     private final TokenProvider tokenProvider;
     private final RefreshTokenStore refreshTokenStore;
+    private final TokenExtractor extractor;
 
     public String createAccessToken(Long memberId) {
         return tokenProvider.createAccessToken(memberId);
@@ -43,15 +44,11 @@ public class TokenService {
     }
 
     public String reissue(HttpServletResponse response, HttpServletRequest request) {
-        String refreshToken = extractRefreshTokenFromCookie(request);
+        validateAccessToken(request);
+
+        String refreshToken = extractor.extractRefreshToken(request);
         Long memberId = tokenProvider.extractMemberId(refreshToken);
-
-        String savedToken = refreshTokenStore.get(memberId)
-                .orElseThrow(() -> new ApiException(AuthApiErrorCode.TOKEN_NOT_FOUND));
-
-        if (!savedToken.equals(refreshToken)) {
-            throw new ApiException(AuthApiErrorCode.TOKEN_INVALID);
-        }
+        validateRefreshToken(refreshToken, memberId);
 
         String newAccessToken = tokenProvider.createAccessToken(memberId);
         createRefreshToken(memberId, response);
@@ -59,15 +56,19 @@ public class TokenService {
         return newAccessToken;
     }
 
-    private String extractRefreshTokenFromCookie(HttpServletRequest request) {
-        if (request.getCookies() == null) {
-            throw new ApiException(AuthApiErrorCode.TOKEN_NOT_FOUND);
+    private void validateAccessToken(HttpServletRequest request) {
+        String accessToken = extractor.extractAccessToken(request);
+        if (!tokenProvider.isAccessTokenExpired(accessToken)) {
+            throw new ApiException(AuthApiErrorCode.TOKEN_NOT_EXPIRED);
         }
+    }
 
-        return Arrays.stream(request.getCookies())
-                .filter(cookie -> COOKIE_NAME.equals(cookie.getName()))
-                .findFirst()
-                .map(Cookie::getValue)
+    private void validateRefreshToken(String refreshToken, Long memberId) {
+        String savedToken = refreshTokenStore.get(memberId)
                 .orElseThrow(() -> new ApiException(AuthApiErrorCode.TOKEN_NOT_FOUND));
+
+        if (!savedToken.equals(refreshToken)) {
+            throw new ApiException(AuthApiErrorCode.TOKEN_INVALID);
+        }
     }
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/service/TokenService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/service/TokenService.java
@@ -1,0 +1,41 @@
+package com.mokakbob.auth.service;
+
+import com.mokakbob.auth.domain.RefreshTokenStore;
+import com.mokakbob.auth.domain.TokenProvider;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TokenService {
+
+    private static final String COOKIE_NAME = "refreshToken";
+    private static final int COOKIE_DURATION = 7 * 24 * 60 * 60;
+    private static final Duration REFRESH_TTL = Duration.ofDays(7);
+
+    private final TokenProvider tokenProvider;
+    private final RefreshTokenStore refreshTokenStore;
+
+    public String createAccessToken(Long memberId) {
+        return tokenProvider.createAccessToken(memberId);
+    }
+
+    public String createRefreshToken(Long memberId) {
+        String refreshToken = tokenProvider.createRefreshToken(memberId);
+        refreshTokenStore.save(memberId, refreshToken, REFRESH_TTL);
+
+        return refreshToken;
+    }
+
+    public void addRefreshTokenToCookie(HttpServletResponse response, String refreshToken) {
+        Cookie cookie = new Cookie(COOKIE_NAME, refreshToken);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setPath("/api/token/reissue");
+        cookie.setMaxAge(COOKIE_DURATION);
+        response.addCookie(cookie);
+    }
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/common/path/auth/AuthApiPath.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/common/path/auth/AuthApiPath.java
@@ -8,4 +8,5 @@ public class AuthApiPath {
 
     public static final String SIGN_UP = BASE + "/signUp";
     public static final String LOGIN = BASE + "/login";
+    public static final String REISSUE = BASE + "/reissue";
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/common/util/TokenExtractor.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/common/util/TokenExtractor.java
@@ -1,0 +1,36 @@
+package com.mokakbob.common.util;
+
+import com.mokakbob.auth.exception.AuthApiErrorCode;
+import com.mokakbob.common.exception.exceptions.ApiException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Arrays;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TokenExtractor {
+
+    private static final String AUTH_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+    private static final String REFRESH_COOKIE_NAME = "refreshToken";
+
+    public String extractAccessToken(HttpServletRequest request) {
+        String header = request.getHeader(AUTH_HEADER);
+        if (header == null || !header.startsWith(BEARER_PREFIX)) {
+            throw new ApiException(AuthApiErrorCode.TOKEN_INVALID);
+        }
+        return header.substring(BEARER_PREFIX.length());
+    }
+
+    public String extractRefreshToken(HttpServletRequest request) {
+        if (request.getCookies() == null) {
+            throw new ApiException(AuthApiErrorCode.TOKEN_NOT_FOUND);
+        }
+
+        return Arrays.stream(request.getCookies())
+                .filter(c -> REFRESH_COOKIE_NAME.equals(c.getName()))
+                .findFirst()
+                .map(Cookie::getValue)
+                .orElseThrow(() -> new ApiException(AuthApiErrorCode.TOKEN_NOT_FOUND));
+    }
+}


### PR DESCRIPTION
## 관련 이슈 번호
#22 closed

## 작업 내용 25.07.30

### AccessToken 재발급 로직 구현
* 크게 두 가지 상황으로 나누어 생각해봤습니다.
  * accessToken 만 만료된 상태
    * 이 경우, referesh 토큰을 파싱하여 memberId 를 가져온 후, accessToken을 재생성하였습니다.
    * 이떄 롤링 방식을 적용하여 refreshToken 도 같이 재생성되게 하였습니다.(보안 강화 목적)
    * 근데 이 경우 서버단에서 accessToken이 만료되지 않았을 경우의 예외처리를 해줘야할까요?? (프론트 쪽에서 accessToken이 만료되었을 때만 재발급 요청 보낸다고 판단하였습니다.)



  * Refresh + accessToken 만료된 상태
    * 이 경우는, refresh 토큰을 파싱하는 과정에서 토큰 유효 기간 예외가 발생하고 -> 프론트 측에서 재로그인 하도록 설계하였습니다.



### Refresh 토큰 관리 방법
* redis 저장소에 memberId 를 키로 하여 7일간 저장되도록 하였습니다.
* accessToken은 응답 Body에 담아 클라이언트에게 전달하고, refreshToken은 보안 설정된 Cookie(HttpOnly + Secure)에 저장되도록 처리하였습니다.
  * AccessToken은 클라이언트에서 쉽게 접근할 수 있어야 하므로 Body로 전달,
  * RefreshToken은 노출되면 위험하므로 보안이 강화된 Cookie에 저장하였습니다.
  * 재발급 요청 시에만 자동으로 쿠키에서 전송되도록 구현하였습니다.