### PR TITLE
#24 [FEAT] 프로필 사진 업로드 기능 뼈대 구현 

### DIFF
--- a/mokakbob-api/build.gradle
+++ b/mokakbob-api/build.gradle
@@ -26,6 +26,9 @@ dependencies {
 
     // passwordEnc
     implementation 'org.springframework.security:spring-security-crypto'
+
+    // s3
+    implementation 'software.amazon.awssdk:s3:2.25.11'
 }
 
 springBoot {

--- a/mokakbob-api/src/main/java/com/mokakbob/member/config/ProfileImageUploaderConfig.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/member/config/ProfileImageUploaderConfig.java
@@ -1,0 +1,24 @@
+package com.mokakbob.member.config;
+
+import com.mokakbob.member.infrastructure.LocalProfileImageUploader;
+import com.mokakbob.member.infrastructure.S3ProfileImageUploader;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class ProfileImageUploaderConfig {
+
+    @Bean
+    @Profile("local")
+    public LocalProfileImageUploader localProfileImageUploader() {
+        return new LocalProfileImageUploader();
+    }
+
+    @Bean
+    @Profile("s3")
+    public S3ProfileImageUploader s3ProfileImageUploader(S3Client s3Client) {
+        return new S3ProfileImageUploader(s3Client);
+    }
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/member/config/S3Config.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/member/config/S3Config.java
@@ -1,0 +1,32 @@
+package com.mokakbob.member.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(accessKey, secretKey)
+                ))
+                .build();
+    }
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/member/controller/ProfileImageController.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/member/controller/ProfileImageController.java
@@ -1,0 +1,12 @@
+package com.mokakbob.member.controller;
+
+import com.mokakbob.member.service.ProfileImageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ProfileImageController {
+
+    private final ProfileImageService profileImageService;
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/member/domain/ProfileImageUploader.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/member/domain/ProfileImageUploader.java
@@ -1,0 +1,8 @@
+package com.mokakbob.member.domain;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface ProfileImageUploader {
+    String upload(MultipartFile file, String directory);
+    void delete(String filePath);
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/member/infrastructure/LocalProfileImageUploader.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/member/infrastructure/LocalProfileImageUploader.java
@@ -2,12 +2,10 @@ package com.mokakbob.member.infrastructure;
 
 import com.mokakbob.member.domain.ProfileImageUploader;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
 @Component
-@Profile("local")
 public class LocalProfileImageUploader implements ProfileImageUploader {
 
     @Value("${local.upload.profile.directory}")

--- a/mokakbob-api/src/main/java/com/mokakbob/member/infrastructure/LocalProfileImageUploader.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/member/infrastructure/LocalProfileImageUploader.java
@@ -1,0 +1,25 @@
+package com.mokakbob.member.infrastructure;
+
+import com.mokakbob.member.domain.ProfileImageUploader;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+@Component
+@Profile("local")
+public class LocalProfileImageUploader implements ProfileImageUploader {
+
+    @Value("${local.upload.profile.directory}")
+    private String uploadDir;
+
+    @Override
+    public String upload(MultipartFile file, String directory) {
+        return "";
+    }
+
+    @Override
+    public void delete(String filePath) {
+
+    }
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/member/infrastructure/S3ProfileImageUploader.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/member/infrastructure/S3ProfileImageUploader.java
@@ -1,0 +1,30 @@
+package com.mokakbob.member.infrastructure;
+
+import com.mokakbob.member.domain.ProfileImageUploader;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Component
+@Profile("s3")
+@RequiredArgsConstructor
+public class S3ProfileImageUploader implements ProfileImageUploader {
+
+    private final S3Client s3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Override
+    public String upload(MultipartFile file, String directory) {
+        return "";
+    }
+
+    @Override
+    public void delete(String filePath) {
+
+    }
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/member/infrastructure/S3ProfileImageUploader.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/member/infrastructure/S3ProfileImageUploader.java
@@ -3,13 +3,11 @@ package com.mokakbob.member.infrastructure;
 import com.mokakbob.member.domain.ProfileImageUploader;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.services.s3.S3Client;
 
 @Component
-@Profile("s3")
 @RequiredArgsConstructor
 public class S3ProfileImageUploader implements ProfileImageUploader {
 

--- a/mokakbob-api/src/main/java/com/mokakbob/member/service/ProfileImageService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/member/service/ProfileImageService.java
@@ -1,0 +1,23 @@
+package com.mokakbob.member.service;
+
+import com.mokakbob.member.domain.ProfileImageUploader;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class ProfileImageService {
+
+    private static final String DEFAULT_PROFILE_DIRECTORY = "profile";
+
+    private final ProfileImageUploader uploader;
+
+    public String uploadProfileImage(MultipartFile file) {
+        return uploader.upload(file, DEFAULT_PROFILE_DIRECTORY);
+    }
+
+    public void deleteProfileImage(String filePath) {
+        uploader.delete(filePath);
+    }
+}


### PR DESCRIPTION
## 관련 이슈 번호
#24 closed

## 작업 내용 25.07.31

* 프로필 이미지 업로드 기능 구현은 크게 로컬과 S3로 나누어 진행할 계획입니다.
* AWS SDK v2 기반의 S3Client를 빈으로 등록했습니다.
  
### 어댑터 패턴 기반 인터페이스 설계
* ProfileImageUploader 인터페이스를 정의하고, 로컬 및 S3 구현체를 구현
* 각 구현체는 `@Profile` 어노테이션 설정에 따라 다르게 실행 가능합니다.

### 참고사항
* 다음 진행상황으로는, 파일 검증 로직 추가하고 업로드 및 삭제 기능 구현 예정입니다!