### PR TITLE
#30 [Feat] 기본 프로필 적용 API 구현

### DIFF
--- a/mokakbob-api/src/main/java/com/mokakbob/auth/service/AuthService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/service/AuthService.java
@@ -6,6 +6,7 @@ import com.mokakbob.domain.member.domain.Member;
 import com.mokakbob.domain.member.domain.vo.MemberPreference;
 import com.mokakbob.domain.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -15,6 +16,9 @@ public class AuthService {
 
     private final MemberService memberService;
     private final PasswordEncoder passwordEncoder;
+
+    @Value("${profile.default.image.url}")
+    private String defaultProfileImageUrl;
 
     public Member login(String email, String password) {
         Member member = memberService.findMemberByEmail(email);
@@ -33,6 +37,7 @@ public class AuthService {
                 email,
                 passwordEnc,
                 nickName,
+                defaultProfileImageUrl,
                 preference
         );
     }

--- a/mokakbob-api/src/main/java/com/mokakbob/common/path/member/ImagePath.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/common/path/member/ImagePath.java
@@ -7,4 +7,5 @@ public class ImagePath {
     private static final String BASE = ApiVersion.V1 + "/image";
 
     public static final String UPLOAD = BASE + "/upload";
+    public static final String DEFAULT = BASE + "/default";
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/member/config/ProfileImageUploaderConfig.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/member/config/ProfileImageUploaderConfig.java
@@ -17,7 +17,7 @@ public class ProfileImageUploaderConfig {
     }
 
     @Bean
-    @Profile("s3")
+    @Profile("prod")
     public S3ProfileImageUploader s3ProfileImageUploader(S3Client s3Client) {
         return new S3ProfileImageUploader(s3Client);
     }

--- a/mokakbob-api/src/main/java/com/mokakbob/member/controller/ProfileImageController.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/member/controller/ProfileImageController.java
@@ -25,4 +25,10 @@ public class ProfileImageController {
         String imagePath = profileImageService.uploadProfileImage(file, memberId);
         return ResponseEntity.ok(new ImageResponse(imagePath));
     }
+
+    @PostMapping(ImagePath.DEFAULT)
+    public ResponseEntity<ImageResponse> defaultImage(@MemberId Long memberId) {
+        String imagePath = profileImageService.applyDefaultImage(memberId);
+        return ResponseEntity.ok(new ImageResponse(imagePath));
+    }
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/member/service/ProfileImageService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/member/service/ProfileImageService.java
@@ -8,6 +8,7 @@ import com.mokakbob.member.exception.MemberApiErrorCode;
 import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -24,6 +25,9 @@ public class ProfileImageService {
     private final ProfileImageUploader uploader;
     private final MemberService memberService;
 
+    @Value("${profile.default.image.url}")
+    private String defaultProfileImageUrl;
+
     @Transactional
     public String uploadProfileImage(MultipartFile file, Long memberId) {
         validateFile(file);
@@ -37,7 +41,6 @@ public class ProfileImageService {
 
         return uploader.upload(file, fileKey);
     }
-
 
     private void deleteProfileImage(String previousImagePath) {
         if (previousImagePath != null && !previousImagePath.isBlank()) {

--- a/mokakbob-api/src/main/java/com/mokakbob/member/service/ProfileImageService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/member/service/ProfileImageService.java
@@ -42,6 +42,21 @@ public class ProfileImageService {
         return uploader.upload(file, fileKey);
     }
 
+    @Transactional
+    public String applyDefaultImage(Long memberId) {
+        Member member = memberService.findMember(memberId);
+
+        String previousImagePath = member.getProfileImage();
+        if (previousImagePath != null && !previousImagePath.isBlank() &&
+                !previousImagePath.equals(defaultProfileImageUrl)) {
+            uploader.delete(previousImagePath);
+        }
+
+        member.updateProfileImage(defaultProfileImageUrl);
+
+        return defaultProfileImageUrl;
+    }
+
     private void deleteProfileImage(String previousImagePath) {
         if (previousImagePath != null && !previousImagePath.isBlank()) {
             uploader.delete(previousImagePath);

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/member/domain/Member.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/member/domain/Member.java
@@ -35,7 +35,7 @@ public class Member extends BaseEntity {
     @Column(nullable = false, unique = true)
     private String nickname;
 
-    // 프로필 이미지: 선택사항
+    @Column(nullable = false)
     private String profileImage;
 
     @Enumerated(EnumType.STRING)

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/member/service/MemberService.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/member/service/MemberService.java
@@ -18,13 +18,15 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
 
+
+
     public Member findMemberByEmail(String email) {
         return memberRepository.findByEmail(email)
                 .orElseThrow(() -> new DomainException(MemberErrorCode.NOT_FOUND_MEMBER_BY_EMAIL));
     }
 
     @Transactional
-    public Member createMember(String email, String passwordEnc, String nickName, MemberPreference preference) {
+    public Member createMember(String email, String passwordEnc, String nickName, String defaultImagePath, MemberPreference preference) {
         validateDuplicateEmail(email);
         validateDuplicateNickName(nickName);
 
@@ -32,6 +34,7 @@ public class MemberService {
                 .email(email)
                 .passwordEnc(passwordEnc)
                 .nickname(nickName)
+                .profileImage(defaultImagePath)
                 .preference(preference)
                 .score(DEFAULT_SCORE)
                 .depositPoint(DEFAULT_POINT)


### PR DESCRIPTION
## 관련 이슈 번호
#30 

## 작업 내용 25.08.01
* 기본 프로필 적용 API 구현

### 회원가입 시 Default 경로 부여
* 기본 프로필 적용을 위해 회원가입 시, default 이미지 경로를 부여했습니다.
* 이에 따라 member table `profileImage` 필드 설정을 `nullable = false`로 업데이트 하였습니다.

### 기본 프로필 적용
* 이미 기본 프로필인 경우
  * [null / blank / 기본 프로필 경로] 검증에 따라, 해당 경로를 삭제하지 않게 하였습니다.

* 기본 프로필이 아닌 경우
  * 해당 경로를 삭제하고 기본 프로필 경로로 업데이트 하였습니다.