### PR TITLE
#32 [FEAT] 깃허브 소셜 로그인 세팅 및 로그인 URL 반환 로직 구현

### DIFF
--- a/mokakbob-api/src/main/java/com/mokakbob/auth/controller/GitHubOauthController.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/controller/GitHubOauthController.java
@@ -1,0 +1,23 @@
+package com.mokakbob.auth.controller;
+
+import com.mokakbob.auth.controller.response.UrlResponse;
+import com.mokakbob.auth.service.GitHubAuthService;
+import com.mokakbob.common.path.auth.GitHubOauthApiPath;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class GitHubOauthController {
+
+    private final GitHubAuthService gitHubAuthService;
+
+    @GetMapping(GitHubOauthApiPath.URL)
+    public ResponseEntity<UrlResponse> getGithubLoginUrl() {
+        String url = gitHubAuthService.getLoginUrl();
+
+        return ResponseEntity.ok(new UrlResponse(url));
+    }
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/controller/response/UrlResponse.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/controller/response/UrlResponse.java
@@ -1,0 +1,6 @@
+package com.mokakbob.auth.controller.response;
+
+public record UrlResponse(
+        String url
+) {
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/domain/AuthClient.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/domain/AuthClient.java
@@ -1,0 +1,6 @@
+package com.mokakbob.auth.domain;
+
+public interface AuthClient {
+
+    String getLoginUrl();
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/infrastructure/GitHubAuthClient.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/infrastructure/GitHubAuthClient.java
@@ -10,10 +10,10 @@ public class GitHubAuthClient implements AuthClient {
 
     private static final String GITHUB_LOGIN_URL = "https://github.com/login/oauth/authorize";
 
-    @Value("${oauth.github.client.idl}")
+    @Value("${oauth.github.client.id}")
     private String clientId;
 
-    @Value("${oauth.github.client.secretl}")
+    @Value("${oauth.github.client.secret}")
     private String clientSecret;
 
     @Value("${oauth.github.redirect.url}")

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/infrastructure/GitHubAuthClient.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/infrastructure/GitHubAuthClient.java
@@ -26,7 +26,7 @@ public class GitHubAuthClient implements AuthClient {
     public String getLoginUrl() {
         return UriComponentsBuilder.fromUriString(GITHUB_LOGIN_URL)
                 .queryParam("client_id", clientId)
-                .queryParam("redirect_uri", clientSecret)
+                .queryParam("redirect_uri", redirectUrl)
                 .queryParam("scope", scope)
                 .build()
                 .toUriString();

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/infrastructure/GitHubAuthClient.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/infrastructure/GitHubAuthClient.java
@@ -1,0 +1,34 @@
+package com.mokakbob.auth.infrastructure;
+
+import com.mokakbob.auth.domain.AuthClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Component
+public class GitHubAuthClient implements AuthClient {
+
+    private static final String GITHUB_LOGIN_URL = "https://github.com/login/oauth/authorize";
+
+    @Value("${oauth.github.client.idl}")
+    private String clientId;
+
+    @Value("${oauth.github.client.secretl}")
+    private String clientSecret;
+
+    @Value("${oauth.github.redirect.url}")
+    private String redirectUrl;
+
+    @Value("${oauth.github.scope}")
+    private String scope;
+
+    @Override
+    public String getLoginUrl() {
+        return UriComponentsBuilder.fromUriString(GITHUB_LOGIN_URL)
+                .queryParam("client_id", clientId)
+                .queryParam("redirect_uri", clientSecret)
+                .queryParam("scope", scope)
+                .build()
+                .toUriString();
+    }
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/service/GitHubAuthService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/service/GitHubAuthService.java
@@ -1,0 +1,16 @@
+package com.mokakbob.auth.service;
+
+import com.mokakbob.auth.infrastructure.GitHubAuthClient;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GitHubAuthService {
+
+    private final GitHubAuthClient client;
+
+    public String getLoginUrl() {
+        return client.getLoginUrl();
+    }
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/common/path/auth/GitHubOauthApiPath.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/common/path/auth/GitHubOauthApiPath.java
@@ -1,0 +1,9 @@
+package com.mokakbob.common.path.auth;
+
+import com.mokakbob.common.path.ApiVersion;
+
+public class GitHubOauthApiPath {
+
+    public static final String BASE = ApiVersion.V1 + "/oauth/github";
+    public static final String URL = BASE + "/url";
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/global/filter/JwtAuthenticationFilter.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/global/filter/JwtAuthenticationFilter.java
@@ -3,6 +3,7 @@ package com.mokakbob.global.filter;
 import com.mokakbob.auth.domain.TokenProvider;
 import com.mokakbob.common.path.auth.AuthApiPath;
 import com.mokakbob.common.path.auth.EmailApiPath;
+import com.mokakbob.common.path.auth.GitHubOauthApiPath;
 import com.mokakbob.common.util.TokenExtractor;
 import com.mokakbob.global.support.AuthConstants;
 import jakarta.servlet.FilterChain;
@@ -33,6 +34,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String uri = request.getRequestURI();
 
         return uri.startsWith(AuthApiPath.BASE) ||
-                uri.startsWith(EmailApiPath.BASE);
+                uri.startsWith(EmailApiPath.BASE) ||
+                uri.startsWith(GitHubOauthApiPath.BASE);
     }
 }


### PR DESCRIPTION
## 관련 이슈 번호
#32 closed

## 작업 내용 25.08.02

* 깃허브로 정한 이유는 처음 해보는 거라, 해보고 싶었습니다!
* 깃허브 소셜 로그인을 위한 세팅 완료했고, `application.properties`에 적용 완료했습니다.

### 소셜 로그인 흐름
1. 로그인 요청하면 로그인 URL 던져줌(scope 는 이메일과 닉네임만)
2. 클라이언트가 인증 코드 전달
3. 인증 코드로 정보 요청
4. 해당 정보를 바탕으로 회원가입 진행 or 로그인

* 해당 순서로 구현할 예정입니다!

### 추후 확장성을 고려한 어댑터 패턴 적용
* OauthClient를 어댑터 패턴으로 구현함으로써, 다른 소셜 로그인 확장성을 고려했습니다.