### PR TITLE
#36 [FEAT] 매칭 참여 토픽 발급 기능 구현

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,39 @@
+version: '3.8'
+
+services:
+  redis:
+    image: redis:7.2
+    container_name: redis
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
+    restart: always
+
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.5.0
+    container_name: zookeeper
+    ports:
+      - "2181:2181"
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    restart: always
+
+  kafka:
+    image: confluentinc/cp-kafka:7.5.0
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+    depends_on:
+      - zookeeper
+    restart: always
+
+volumes:
+  redis-data:

--- a/mokakbob-api/build.gradle
+++ b/mokakbob-api/build.gradle
@@ -33,6 +33,9 @@ dependencies {
     // oauth2 security
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+    // kafka
+    implementation 'org.springframework.kafka:spring-kafka'
 }
 
 springBoot {

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/config/SecurityConfig.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/config/SecurityConfig.java
@@ -1,6 +1,5 @@
 package com.mokakbob.auth.config;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mokakbob.auth.handler.OAuth2SuccessLoginHandler;
 import com.mokakbob.auth.service.CustomOAuth2UserService;
 import com.mokakbob.common.path.permit.PermitPath;
@@ -10,7 +9,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -37,16 +35,7 @@ public class SecurityConfig {
     }
 
     @Bean
-    public WebSecurityCustomizer webSecurityCustomizer() {
-        return web -> web.ignoring()
-                .requestMatchers(
-                        "/favicon.ico",
-                        "/error"
-                );
-    }
-
-    @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http, ObjectMapper mapper) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 // 기본 보안 설정 비활성화
                 .csrf(AbstractHttpConfigurer::disable)
@@ -63,7 +52,9 @@ public class SecurityConfig {
                         .requestMatchers(
                                 PermitPath.AUTH_BASE + WILD_CARD_PATH,          // 일반 회원가입
                                 PermitPath.EMAIL_BASE + WILD_CARD_PATH,        // 이메일 인증
-                                "/login/oauth2/**"          // Oauth 콜백 URI
+                                "/login/oauth2/**",                         // Oauth 콜백 URI
+                                "/favicon.ico",
+                                "/error"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/infrastructure/RedisEmailVerifyCodeStore.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/infrastructure/RedisEmailVerifyCodeStore.java
@@ -13,12 +13,12 @@ public class RedisEmailVerifyCodeStore implements EmailVerifyCodeStore {
 
     private static final String EMAIL_KEY_PREFIX = "email:verify:";
 
-    private final RedisTemplate<String, String> authRedisTemplate;
+    private final RedisTemplate<String, String> basicRedisTemplate;
 
     @Override
     public void saveCode(String email, String code, Duration expiration) {
         String key = EMAIL_KEY_PREFIX + email;
-        authRedisTemplate.opsForValue()
+        basicRedisTemplate.opsForValue()
                 .set(key, code, expiration);
     }
 
@@ -26,14 +26,14 @@ public class RedisEmailVerifyCodeStore implements EmailVerifyCodeStore {
     public Optional<String> getCode(String email) {
         String key = EMAIL_KEY_PREFIX + email;
 
-        return Optional.ofNullable(authRedisTemplate.opsForValue()
+        return Optional.ofNullable(basicRedisTemplate.opsForValue()
                 .get(key));
     }
 
     @Override
     public void deleteCode(String email) {
         String key = EMAIL_KEY_PREFIX + email;
-        authRedisTemplate.delete(key);
+        basicRedisTemplate.delete(key);
     }
 
     @Override
@@ -41,6 +41,6 @@ public class RedisEmailVerifyCodeStore implements EmailVerifyCodeStore {
         String key = EMAIL_KEY_PREFIX + email;
 
         return Boolean.TRUE
-                .equals(authRedisTemplate.hasKey(key));
+                .equals(basicRedisTemplate.hasKey(key));
     }
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/infrastructure/RedisRefreshTokenStore.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/infrastructure/RedisRefreshTokenStore.java
@@ -13,29 +13,29 @@ public class RedisRefreshTokenStore implements RefreshTokenStore {
 
     private static final String TOKEN_KEY_PREFIX = "refresh:";
 
-    private final RedisTemplate<String, String> authRedisTemplate;
+    private final RedisTemplate<String, String> basicRedisTemplate;
 
     @Override
     public void save(Long memberId, String refreshToken, Duration ttl) {
-        authRedisTemplate.opsForValue()
+        basicRedisTemplate.opsForValue()
                 .set(key(memberId), refreshToken, ttl);
     }
 
     @Override
     public Optional<String> get(Long memberId) {
-        return Optional.ofNullable(authRedisTemplate.opsForValue()
+        return Optional.ofNullable(basicRedisTemplate.opsForValue()
                 .get(key(memberId)));
     }
 
     @Override
     public void delete(Long memberId) {
-        authRedisTemplate.delete(key(memberId));
+        basicRedisTemplate.delete(key(memberId));
     }
 
     @Override
     public boolean exists(Long memberId) {
         return Boolean.TRUE
-                .equals(authRedisTemplate.hasKey(key(memberId)));
+                .equals(basicRedisTemplate.hasKey(key(memberId)));
     }
 
     private String key(Long memberId) {

--- a/mokakbob-api/src/main/java/com/mokakbob/common/path/matching/MatchingPath.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/common/path/matching/MatchingPath.java
@@ -1,0 +1,6 @@
+package com.mokakbob.common.path.matching;
+
+public class MatchingPath {
+
+    public static final String PARTICIPATE = "/api/v1/matchings/participation";
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/common/path/matching/MatchingPath.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/common/path/matching/MatchingPath.java
@@ -2,5 +2,5 @@ package com.mokakbob.common.path.matching;
 
 public class MatchingPath {
 
-    public static final String PARTICIPATE = "/api/v1/matchings/participation";
+    public static final String PARTICIPATE = "/api/v1/matchings/participate";
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/config/KafkaProducerConfig.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/config/KafkaProducerConfig.java
@@ -1,7 +1,7 @@
 package com.mokakbob.matching.config;
 
 import com.mokakbob.matching.infrastructure.KafkaProducerLoggingListener;
-import com.nimbusds.jose.shaded.gson.JsonSerializer;
+
 import java.util.HashMap;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +13,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
 
 @Configuration
 @RequiredArgsConstructor

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/config/KafkaProducerConfig.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/config/KafkaProducerConfig.java
@@ -1,0 +1,51 @@
+package com.mokakbob.matching.config;
+
+import com.mokakbob.matching.infrastructure.KafkaProducerLoggingListener;
+import com.nimbusds.jose.shaded.gson.JsonSerializer;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+
+@Configuration
+@RequiredArgsConstructor
+public class KafkaProducerConfig {
+
+    private final KafkaProducerLoggingListener loggingListener;
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Bean
+    public ProducerFactory<String, Object> producerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+
+        props.put(ProducerConfig.ACKS_CONFIG, "all");
+        props.put(ProducerConfig.RETRIES_CONFIG, 3);
+        props.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
+        props.put(ProducerConfig.LINGER_MS_CONFIG, 10);
+        props.put(ProducerConfig.BATCH_SIZE_CONFIG, 16384);
+        props.put(ProducerConfig.BUFFER_MEMORY_CONFIG, 33554432);
+        props.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 5);
+        props.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, "snappy");
+
+        return new DefaultKafkaProducerFactory<>(props);
+    }
+
+    @Bean
+    public KafkaTemplate<String, Object> kafkaTemplate() {
+        KafkaTemplate<String, Object> template = new KafkaTemplate<>(producerFactory());
+        template.setProducerListener(loggingListener);
+        return template;
+    }
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/config/KafkaTopics.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/config/KafkaTopics.java
@@ -1,0 +1,8 @@
+package com.mokakbob.matching.config;
+
+public class KafkaTopics {
+
+    public static final String MATCHING_PARTICIPATE = "matching.participate";
+    public static final String MATCHING_FOUND = "matching.found";
+    public static final String MATCHING_SUCCESS = "matching.success";
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/constant/KafkaTopics.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/constant/KafkaTopics.java
@@ -1,4 +1,4 @@
-package com.mokakbob.matching.config;
+package com.mokakbob.matching.constant;
 
 public class KafkaTopics {
 

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/controller/MatchingController.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/controller/MatchingController.java
@@ -1,0 +1,24 @@
+package com.mokakbob.matching.controller;
+
+import com.mokakbob.global.resolver.annotation.MemberId;
+import com.mokakbob.matching.controller.request.MatchingStartRequest;
+import com.mokakbob.matching.service.MatchingStartService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class MatchingController {
+
+    private final MatchingStartService startService;
+
+    public ResponseEntity<Void> startMatching(
+            @RequestBody MatchingStartRequest request,
+            @MemberId Long memberId
+            ) {
+        return ResponseEntity.ok()
+                .build();
+    }
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/controller/MatchingController.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/controller/MatchingController.java
@@ -20,7 +20,15 @@ public class MatchingController {
     public ResponseEntity<Void> startMatching(
             @RequestBody MatchingStartRequest request,
             @MemberId Long memberId
-            ) {
+    ) {
+        startService.participateMatching(
+                request.lat(),
+                request.lng(),
+                request.category(),
+                request.participantCount(),
+                memberId
+        );
+
         return ResponseEntity.ok()
                 .build();
     }

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/controller/MatchingController.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/controller/MatchingController.java
@@ -1,10 +1,12 @@
 package com.mokakbob.matching.controller;
 
+import com.mokakbob.common.path.matching.MatchingPath;
 import com.mokakbob.global.resolver.annotation.MemberId;
 import com.mokakbob.matching.controller.request.MatchingStartRequest;
 import com.mokakbob.matching.service.MatchingStartService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -14,6 +16,7 @@ public class MatchingController {
 
     private final MatchingStartService startService;
 
+    @PostMapping(MatchingPath.PARTICIPATE)
     public ResponseEntity<Void> startMatching(
             @RequestBody MatchingStartRequest request,
             @MemberId Long memberId

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/controller/request/MatchingStartRequest.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/controller/request/MatchingStartRequest.java
@@ -1,0 +1,25 @@
+package com.mokakbob.matching.controller.request;
+
+import com.mokakbob.domain.matching.domain.vo.MatchingCategory;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+
+public record MatchingStartRequest(
+        @NotBlank
+        @DecimalMin("-90.0") @DecimalMax("90.0")
+        Double lat,
+
+        @NotBlank
+        @DecimalMin("-180.0") @DecimalMax("180.0")
+        Double lng,
+
+        @NotBlank
+        MatchingCategory category,
+
+        @Min(1) @Max(4)
+        int participantCount
+) {
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/controller/request/MatchingStartRequest.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/controller/request/MatchingStartRequest.java
@@ -9,17 +9,20 @@ import jakarta.validation.constraints.NotBlank;
 
 public record MatchingStartRequest(
         @NotBlank
-        @DecimalMin("-90.0") @DecimalMax("90.0")
+        @DecimalMin("-90.0")
+        @DecimalMax("90.0")
         Double lat,
 
         @NotBlank
-        @DecimalMin("-180.0") @DecimalMax("180.0")
+        @DecimalMin("-180.0")
+        @DecimalMax("180.0")
         Double lng,
 
         @NotBlank
         MatchingCategory category,
 
-        @Min(1) @Max(4)
+        @Min(1)
+        @Max(4)
         int participantCount
 ) {
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/domain/CategoryQueueStore.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/domain/CategoryQueueStore.java
@@ -1,0 +1,10 @@
+package com.mokakbob.matching.domain;
+
+import com.mokakbob.domain.matching.domain.vo.MatchingCategory;
+import java.util.List;
+
+public interface CategoryQueueStore {
+    void addToQueue(MatchingCategory category, int count, Long memberId);
+    void removeFromQueue(MatchingCategory category, int count, Long memberId);
+    List<Long> findWaitingUsers(MatchingCategory category, int count);
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/domain/ParticipantGeoStore.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/domain/ParticipantGeoStore.java
@@ -1,0 +1,10 @@
+package com.mokakbob.matching.domain;
+
+import java.util.List;
+
+public interface ParticipantGeoStore {
+
+    void addUserLocation(Long userId, double lng, double lat);
+    List<Long> findNearbyUsers(double lng, double lat, double radiusInMeters);
+    void removeUserLocation(Long userId);
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/domain/ParticipantGeoStore.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/domain/ParticipantGeoStore.java
@@ -6,5 +6,5 @@ public interface ParticipantGeoStore {
 
     void addUserLocation(Long userId, double lng, double lat);
     List<Long> findNearbyUsers(double lng, double lat, double radiusInMeters);
-    void removeUserLocation(Long userId);
+    void removeMemberLocation(Long userId);
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/domain/ParticipantGeoStore.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/domain/ParticipantGeoStore.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 public interface ParticipantGeoStore {
 
-    void addUserLocation(Long userId, double lng, double lat);
-    List<Long> findNearbyUsers(double lng, double lat, double radiusInMeters);
-    void removeMemberLocation(Long userId);
+    void addMemberLocation(Long memberId, double lng, double lat);
+    List<Long> findNearbyMembers(double lng, double lat, double radiusInMeters);
+    void removeMemberLocation(Long memberId);
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/domain/ParticipantStore.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/domain/ParticipantStore.java
@@ -7,5 +7,5 @@ public interface ParticipantStore {
     void transitionToParticipating(Long memberId);
     void transitionToFound(Long memberId);
     void clearAll(Long memberId);
-    MatchingRequestStatus getStatue(Long memberId);
+    MatchingRequestStatus getStatus(Long memberId);
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/domain/ParticipantStore.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/domain/ParticipantStore.java
@@ -1,0 +1,11 @@
+package com.mokakbob.matching.domain;
+
+import com.mokakbob.domain.matching.domain.vo.MatchingRequestStatus;
+
+public interface ParticipantStore {
+    boolean isAlreadyParticipating(Long memberId);
+    void transitionToParticipating(Long memberId);
+    void transitionToFound(Long memberId);
+    void clearAll(Long memberId);
+    MatchingRequestStatus getStatue(Long memberId);
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/exception/MatchingErrorCode.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/exception/MatchingErrorCode.java
@@ -1,0 +1,32 @@
+package com.mokakbob.matching.exception;
+
+import com.mokakbob.common.exception.exceptions.ApiErrorCode;
+
+public enum MatchingErrorCode implements ApiErrorCode {
+    EXIST_MATCHING(400, "M001", "이미 매칭에 참여 중입니다.")
+    ;
+    private final int httpStatus;
+    private final String customCode;
+    private final String message;
+
+    MatchingErrorCode(int httpStatus, String customCode, String message) {
+        this.httpStatus = httpStatus;
+        this.customCode = customCode;
+        this.message = message;
+    }
+
+    @Override
+    public int httpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String customCode() {
+        return customCode;
+    }
+
+    @Override
+    public String message() {
+        return message;
+    }
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/infrastructure/CategoryQueueRedisStore.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/infrastructure/CategoryQueueRedisStore.java
@@ -17,14 +17,14 @@ public class CategoryQueueRedisStore implements CategoryQueueStore {
     private static final String ZSET_CATEGORY_KEY = "matching:zset:%s:%d";
     private static final String MEMBER_KEY = "member:";
 
-    private final RedisTemplate<String, String> redisTemplate;
+    private final RedisTemplate<String, String> basicRedisTemplate;
 
     @Override
     public void addToQueue(MatchingCategory category, int count, Long memberId) {
         String zsetKey = zsetKey(category, count);
         double score = System.currentTimeMillis();
 
-        redisTemplate.opsForZSet()
+        basicRedisTemplate.opsForZSet()
                 .add(zsetKey, memberKey(memberId), score);
     }
 
@@ -32,7 +32,7 @@ public class CategoryQueueRedisStore implements CategoryQueueStore {
     public void removeFromQueue(MatchingCategory category, int count, Long memberId) {
         String zsetKey = zsetKey(category, count);
 
-        redisTemplate.opsForZSet()
+        basicRedisTemplate.opsForZSet()
                 .remove(zsetKey, memberKey(memberId));
     }
 
@@ -40,7 +40,7 @@ public class CategoryQueueRedisStore implements CategoryQueueStore {
     public List<Long> findWaitingUsers(MatchingCategory category, int count) {
         String zsetKey = zsetKey(category, count);
 
-        Set<String> members = redisTemplate.opsForZSet()
+        Set<String> members = basicRedisTemplate.opsForZSet()
                 .range(zsetKey, 0, count - 1);
 
         if (members == null || members.isEmpty()) {

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/infrastructure/CategoryQueueRedisStore.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/infrastructure/CategoryQueueRedisStore.java
@@ -1,0 +1,75 @@
+package com.mokakbob.matching.infrastructure;
+
+import com.mokakbob.domain.matching.domain.vo.MatchingCategory;
+import com.mokakbob.matching.domain.CategoryQueueStore;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CategoryQueueRedisStore implements CategoryQueueStore {
+
+    private static final String ZSET_CATEGORY_KEY = "matching:zset:%s:%d";
+    private static final String MEMBER_KEY = "member:";
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Override
+    public void addToQueue(MatchingCategory category, int count, Long memberId) {
+        String zsetKey = zsetKey(category, count);
+        double score = System.currentTimeMillis();
+
+        redisTemplate.opsForZSet()
+                .add(zsetKey, memberKey(memberId), score);
+    }
+
+    @Override
+    public void removeFromQueue(MatchingCategory category, int count, Long memberId) {
+        String zsetKey = zsetKey(category, count);
+
+        redisTemplate.opsForZSet()
+                .remove(zsetKey, memberKey(memberId));
+    }
+
+    @Override
+    public List<Long> findWaitingUsers(MatchingCategory category, int count) {
+        String zsetKey = zsetKey(category, count);
+
+        Set<String> members = redisTemplate.opsForZSet()
+                .range(zsetKey, 0, count - 1);
+
+        if (members == null || members.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return members.stream()
+                .map(this::extractMemberId)
+                .flatMap(Optional::stream)
+                .toList();
+    }
+
+    private String zsetKey(MatchingCategory category, int participantCount) {
+        return ZSET_CATEGORY_KEY.formatted(category.name(), participantCount);
+    }
+
+    private String memberKey(Long memberId) {
+        return MEMBER_KEY + memberId;
+    }
+
+    private Optional<Long> extractMemberId(String value) {
+        if (value != null && value.startsWith(MEMBER_KEY)) {
+            try {
+                return Optional.of(Long.parseLong(value.substring(7)));
+            } catch (NumberFormatException e) {
+                return Optional.empty();
+            }
+        }
+
+        return Optional.empty();
+    }
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/infrastructure/KafkaProducerLoggingListener.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/infrastructure/KafkaProducerLoggingListener.java
@@ -1,0 +1,23 @@
+package com.mokakbob.matching.infrastructure;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.springframework.kafka.support.ProducerListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class KafkaProducerLoggingListener implements ProducerListener<String, Object> {
+
+    @Override
+    public void onSuccess(ProducerRecord<String, Object> record, RecordMetadata metadata) {
+        log.info("Kafka 메시지 전송 성공 - Topic: {}, Partition: {}, Offset: {}",
+                metadata.topic(), metadata.partition(), metadata.offset());
+    }
+
+    @Override
+    public void onError(ProducerRecord<String, Object> record, RecordMetadata metadata, Exception exception) {
+        log.error("Kafka 메시지 전송 실패", exception);
+    }
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/infrastructure/MatchingParticipantStore.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/infrastructure/MatchingParticipantStore.java
@@ -14,7 +14,7 @@ public class MatchingParticipantStore implements ParticipantStore {
 
     private static final String PARTICIPATE_KEY = "user:%d:matching:participate";
     private static final String FOUND_KEY = "user:%d:matching:found";
-    private static final Duration DEFAULT_TTL = Duration.ofHours(15);
+    private static final Duration DEFAULT_TTL = Duration.ofHours(1);
     private static final String SHOW_EXIST = "1";
 
     private final RedisTemplate<String, String> basicRedisTemplate;

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/infrastructure/MatchingParticipantStore.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/infrastructure/MatchingParticipantStore.java
@@ -1,0 +1,75 @@
+package com.mokakbob.matching.infrastructure;
+
+import com.mokakbob.domain.matching.domain.vo.MatchingRequestStatus;
+import com.mokakbob.matching.domain.ParticipantStore;
+import java.time.Duration;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MatchingParticipantStore implements ParticipantStore {
+
+    private static final String PARTICIPATE_KEY = "user:%d:matching:participate";
+    private static final String FOUND_KEY = "user:%d:matching:found";
+    private static final Duration DEFAULT_TTL = Duration.ofHours(15);
+    private static final String SHOW_EXIST = "1";
+
+    private final RedisTemplate<String, String> basicRedisTemplate;
+
+    @Override
+    public boolean isAlreadyParticipating(Long memberId) {
+        return Boolean.TRUE.equals(basicRedisTemplate.hasKey(participateKey(memberId))) ||
+                Boolean.TRUE.equals(basicRedisTemplate.hasKey(foundKey(memberId)));
+    }
+
+    @Override
+    public void transitionToParticipating(Long memberId) {
+        deleteAllStates(memberId);
+        basicRedisTemplate.opsForValue()
+                .set(participateKey(memberId), SHOW_EXIST, DEFAULT_TTL);
+    }
+
+    @Override
+    public void transitionToFound(Long memberId) {
+        basicRedisTemplate.delete(participateKey(memberId));
+        basicRedisTemplate.opsForValue()
+                .set(foundKey(memberId), SHOW_EXIST, DEFAULT_TTL);
+    }
+
+    @Override
+    public void clearAll(Long memberId) {
+        deleteAllStates(memberId);
+    }
+
+    @Override
+    public MatchingRequestStatus getStatue(Long memberId) {
+        if (Boolean.TRUE.equals(basicRedisTemplate.hasKey(foundKey(memberId)))) {
+            return MatchingRequestStatus.FOUND;
+        }
+
+        if (Boolean.TRUE.equals(basicRedisTemplate.hasKey(participateKey(memberId)))) {
+            return MatchingRequestStatus.PARTICIPATE;
+        }
+
+        return MatchingRequestStatus.NONE;
+    }
+
+    private void deleteAllStates(Long memberId) {
+        basicRedisTemplate.delete(List.of(
+                participateKey(memberId),
+                foundKey(memberId)
+        ));
+    }
+
+    private String participateKey(Long memberId) {
+        return PARTICIPATE_KEY.formatted(memberId);
+    }
+
+    private String foundKey(Long memberId) {
+        return FOUND_KEY.formatted(memberId);
+    }
+
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/infrastructure/ParticipantGeoRedisStore.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/infrastructure/ParticipantGeoRedisStore.java
@@ -24,7 +24,7 @@ public class ParticipantGeoRedisStore implements ParticipantGeoStore {
     private final RedisTemplate<String, String> basicRedisTemplate;
 
     @Override
-    public void addUserLocation(Long memberId, double lng, double lat) {
+    public void addMemberLocation(Long memberId, double lng, double lat) {
         String member = memberKey(memberId);
 
         basicRedisTemplate.opsForGeo()
@@ -32,7 +32,7 @@ public class ParticipantGeoRedisStore implements ParticipantGeoStore {
     }
 
     @Override
-    public List<Long> findNearbyUsers(double lng, double lat, double radiusInMeters) {
+    public List<Long> findNearbyMembers(double lng, double lat, double radiusInMeters) {
         GeoResults<GeoLocation<String>> results = basicRedisTemplate.opsForGeo()
                 .radius(
                         GEO_KEY,

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/infrastructure/ParticipantGeoRedisStore.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/infrastructure/ParticipantGeoRedisStore.java
@@ -50,8 +50,8 @@ public class ParticipantGeoRedisStore implements ParticipantGeoStore {
     }
 
     @Override
-    public void removeUserLocation(Long memberId) {
-        basicRedisTemplate.opsForZSet()
+    public void removeMemberLocation(Long memberId) {
+        basicRedisTemplate.opsForGeo()
                 .remove(GEO_KEY, memberKey(memberId));
     }
 

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/infrastructure/ParticipantGeoRedisStore.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/infrastructure/ParticipantGeoRedisStore.java
@@ -1,0 +1,71 @@
+package com.mokakbob.matching.infrastructure;
+
+import com.mokakbob.matching.domain.ParticipantGeoStore;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.geo.Circle;
+import org.springframework.data.geo.Distance;
+import org.springframework.data.geo.GeoResults;
+import org.springframework.data.geo.Point;
+import org.springframework.data.redis.connection.RedisGeoCommands.GeoLocation;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.domain.geo.Metrics;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ParticipantGeoRedisStore implements ParticipantGeoStore {
+
+    private static final String GEO_KEY = "matching:geo";
+
+    private final RedisTemplate<String, String> basicRedisTemplate;
+
+    @Override
+    public void addUserLocation(Long userId, double lng, double lat) {
+        String member = userKey(userId);
+
+        basicRedisTemplate.opsForGeo()
+                .add(GEO_KEY, new Point(lng, lat), member);
+    }
+
+    @Override
+    public List<Long> findNearbyUsers(double lng, double lat, double radiusInMeters) {
+        GeoResults<GeoLocation<String>> results = basicRedisTemplate.opsForGeo()
+                .radius(
+                        GEO_KEY,
+                        new Circle(new Point(lng, lat), new Distance(radiusInMeters, Metrics.METERS))
+                );
+
+        if (results == null) {
+            return Collections.emptyList();
+        }
+
+        return results.getContent().stream()
+                .map(result -> extractUserId(result.getContent().getName()))
+                .flatMap(Optional::stream)
+                .toList();
+    }
+
+    @Override
+    public void removeUserLocation(Long userId) {
+        basicRedisTemplate.opsForZSet()
+                .remove(GEO_KEY, userKey(userId));
+    }
+
+    private String userKey(Long userId) {
+        return "user:" + userId;
+    }
+
+    private Optional<Long> extractUserId(String value) {
+        if (value != null && value.startsWith("user:")) {
+            try {
+                return Optional.of(Long.parseLong(value.substring(5)));
+            } catch (NumberFormatException e) {
+                return Optional.empty();
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/infrastructure/ParticipantGeoRedisStore.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/infrastructure/ParticipantGeoRedisStore.java
@@ -19,12 +19,13 @@ import org.springframework.stereotype.Component;
 public class ParticipantGeoRedisStore implements ParticipantGeoStore {
 
     private static final String GEO_KEY = "matching:geo";
+    private static final String MEMBER_KEY = "member:";
 
     private final RedisTemplate<String, String> basicRedisTemplate;
 
     @Override
-    public void addUserLocation(Long userId, double lng, double lat) {
-        String member = userKey(userId);
+    public void addUserLocation(Long memberId, double lng, double lat) {
+        String member = memberKey(memberId);
 
         basicRedisTemplate.opsForGeo()
                 .add(GEO_KEY, new Point(lng, lat), member);
@@ -49,17 +50,17 @@ public class ParticipantGeoRedisStore implements ParticipantGeoStore {
     }
 
     @Override
-    public void removeUserLocation(Long userId) {
+    public void removeUserLocation(Long memberId) {
         basicRedisTemplate.opsForZSet()
-                .remove(GEO_KEY, userKey(userId));
+                .remove(GEO_KEY, memberKey(memberId));
     }
 
-    private String userKey(Long userId) {
-        return "user:" + userId;
+    private String memberKey(Long memberId) {
+        return MEMBER_KEY + memberId;
     }
 
     private Optional<Long> extractUserId(String value) {
-        if (value != null && value.startsWith("user:")) {
+        if (value != null && value.startsWith(MEMBER_KEY)) {
             try {
                 return Optional.of(Long.parseLong(value.substring(5)));
             } catch (NumberFormatException e) {

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/infrastructure/ParticipantRedisStore.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/infrastructure/ParticipantRedisStore.java
@@ -45,7 +45,7 @@ public class ParticipantRedisStore implements ParticipantStore {
     }
 
     @Override
-    public MatchingRequestStatus getStatue(Long memberId) {
+    public MatchingRequestStatus getStatus(Long memberId) {
         if (Boolean.TRUE.equals(basicRedisTemplate.hasKey(foundKey(memberId)))) {
             return MatchingRequestStatus.FOUND;
         }

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/infrastructure/ParticipantRedisStore.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/infrastructure/ParticipantRedisStore.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class MatchingParticipantStore implements ParticipantStore {
+public class ParticipantRedisStore implements ParticipantStore {
 
     private static final String PARTICIPATE_KEY = "user:%d:matching:participate";
     private static final String FOUND_KEY = "user:%d:matching:found";
@@ -71,5 +71,4 @@ public class MatchingParticipantStore implements ParticipantStore {
     private String foundKey(Long memberId) {
         return FOUND_KEY.formatted(memberId);
     }
-
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/infrastructure/ParticipantRedisStore.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/infrastructure/ParticipantRedisStore.java
@@ -12,8 +12,8 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class ParticipantRedisStore implements ParticipantStore {
 
-    private static final String PARTICIPATE_KEY = "user:%d:matching:participate";
-    private static final String FOUND_KEY = "user:%d:matching:found";
+    private static final String PARTICIPATE_KEY = "member:%d:matching:participate";
+    private static final String FOUND_KEY = "member:%d:matching:found";
     private static final Duration DEFAULT_TTL = Duration.ofHours(1);
     private static final String SHOW_EXIST = "1";
 

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/listener/MatchingParticipateEventListener.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/listener/MatchingParticipateEventListener.java
@@ -1,0 +1,31 @@
+package com.mokakbob.matching.listener;
+
+import com.mokakbob.matching.constant.KafkaTopics;
+import com.mokakbob.matching.domain.CategoryQueueStore;
+import com.mokakbob.matching.domain.ParticipantGeoStore;
+import com.mokakbob.matching.domain.ParticipantStore;
+import com.mokakbob.matching.service.event.MatchingParticipateEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class MatchingParticipateEventListener {
+
+    private final KafkaTemplate<String, MatchingParticipateEvent> kafkaTemplate;
+    private final ParticipantStore participantStore;
+    private final ParticipantGeoStore geoStore;
+    private final CategoryQueueStore categoryQueueStore;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleMatchingParticipateEvent(MatchingParticipateEvent event) {
+        kafkaTemplate.send(KafkaTopics.MATCHING_PARTICIPATE, event);
+
+        participantStore.transitionToParticipating(event.memberId());
+        geoStore.addMemberLocation(event.memberId(), event.lng(), event.lat());
+        categoryQueueStore.addToQueue(event.category(), event.participantCount(), event.memberId());
+    }
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/service/MatchingStartService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/service/MatchingStartService.java
@@ -5,15 +5,12 @@ import com.mokakbob.domain.matching.domain.vo.MatchingCategory;
 import com.mokakbob.domain.matching.service.MatchingService;
 import com.mokakbob.domain.member.domain.Member;
 import com.mokakbob.domain.member.service.MemberService;
-import com.mokakbob.matching.constant.KafkaTopics;
-import com.mokakbob.matching.domain.CategoryQueueStore;
-import com.mokakbob.matching.domain.ParticipantGeoStore;
 import com.mokakbob.matching.exception.MatchingErrorCode;
 import com.mokakbob.matching.infrastructure.ParticipantRedisStore;
 import com.mokakbob.matching.service.event.MatchingParticipateEvent;
 import java.math.BigDecimal;
 import lombok.RequiredArgsConstructor;
-import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,28 +21,22 @@ public class MatchingStartService {
     private static final int DEFAULT_DEDUCE_POINT = 2000;
 
     private final ParticipantRedisStore participantStore;
-    private final ParticipantGeoStore geoStore;
     private final MemberService memberService;
     private final MatchingService matchingService;
-    private final CategoryQueueStore categoryQueueStore;
-    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public void participateMatching(double lat, double lng, MatchingCategory category, int participantCount,
                                     Long memberId) {
-        participantStore.clearAll(memberId);
         validateExistParticipating(memberId);
         deducePoint(memberId);
 
         matchingService.saveMatchingRequest(memberId, category, participantCount, new BigDecimal(lat),
                 new BigDecimal(lng));
 
-        geoStore.addUserLocation(memberId, lng, lat);
-        participantStore.transitionToParticipating(memberId);
-        categoryQueueStore.addToQueue(category, participantCount, memberId);
-
-        MatchingParticipateEvent event = new MatchingParticipateEvent(memberId, lat, lng, category, participantCount);
-        kafkaTemplate.send(KafkaTopics.MATCHING_PARTICIPATE, event);
+        eventPublisher.publishEvent(
+                new MatchingParticipateEvent(memberId, lat, lng, category, participantCount)
+        );
     }
 
     private void deducePoint(Long memberId) {

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/service/MatchingStartService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/service/MatchingStartService.java
@@ -1,12 +1,46 @@
 package com.mokakbob.matching.service;
 
+import com.mokakbob.common.exception.exceptions.ApiException;
 import com.mokakbob.domain.matching.domain.vo.MatchingCategory;
+import com.mokakbob.domain.matching.service.MatchingService;
+import com.mokakbob.domain.member.domain.Member;
+import com.mokakbob.domain.member.service.MemberService;
+import com.mokakbob.matching.exception.MatchingErrorCode;
+import com.mokakbob.matching.infrastructure.MatchingParticipantStore;
+import java.math.BigDecimal;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class MatchingStartService {
 
-    public void startMatching(double lat, double lng, MatchingCategory category, int participantCount, Long memberId) {
+    private static final int DEFAULT_DEDUCE_POINT = 2000;
 
+    private final MatchingParticipantStore participantStore;
+    private final MemberService memberService;
+    private final MatchingService matchingService;
+
+    public void startMatching(double lat, double lng, MatchingCategory category, int participantCount, Long memberId) {
+        validateExistParticipating(memberId);
+        deducePoint(memberId);
+        matchingService.saveMatchingRequest(
+                memberId,
+                category,
+                participantCount,
+                new BigDecimal(lat),
+                new BigDecimal(lng)
+        );
+    }
+
+    private void deducePoint(Long memberId) {
+        Member member = memberService.findMember(memberId);
+        member.deductPoint(DEFAULT_DEDUCE_POINT);
+    }
+
+    private void validateExistParticipating(Long memberId) {
+        if(participantStore.isAlreadyParticipating(memberId)) {
+            throw new ApiException(MatchingErrorCode.EXIST_MATCHING);
+        }
     }
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/service/MatchingStartService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/service/MatchingStartService.java
@@ -5,6 +5,7 @@ import com.mokakbob.domain.matching.domain.vo.MatchingCategory;
 import com.mokakbob.domain.matching.service.MatchingService;
 import com.mokakbob.domain.member.domain.Member;
 import com.mokakbob.domain.member.service.MemberService;
+import com.mokakbob.matching.domain.ParticipantGeoStore;
 import com.mokakbob.matching.exception.MatchingErrorCode;
 import com.mokakbob.matching.infrastructure.ParticipantRedisStore;
 import java.math.BigDecimal;
@@ -18,12 +19,14 @@ public class MatchingStartService {
     private static final int DEFAULT_DEDUCE_POINT = 2000;
 
     private final ParticipantRedisStore participantStore;
+    private final ParticipantGeoStore geoStore;
     private final MemberService memberService;
     private final MatchingService matchingService;
 
     public void startMatching(double lat, double lng, MatchingCategory category, int participantCount, Long memberId) {
         validateExistParticipating(memberId);
         deducePoint(memberId);
+
         matchingService.saveMatchingRequest(
                 memberId,
                 category,
@@ -31,6 +34,8 @@ public class MatchingStartService {
                 new BigDecimal(lat),
                 new BigDecimal(lng)
         );
+
+        geoStore.addUserLocation(memberId, lng, lat);
     }
 
     private void deducePoint(Long memberId) {

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/service/MatchingStartService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/service/MatchingStartService.java
@@ -5,6 +5,7 @@ import com.mokakbob.domain.matching.domain.vo.MatchingCategory;
 import com.mokakbob.domain.matching.service.MatchingService;
 import com.mokakbob.domain.member.domain.Member;
 import com.mokakbob.domain.member.service.MemberService;
+import com.mokakbob.matching.domain.CategoryQueueStore;
 import com.mokakbob.matching.domain.ParticipantGeoStore;
 import com.mokakbob.matching.exception.MatchingErrorCode;
 import com.mokakbob.matching.infrastructure.ParticipantRedisStore;
@@ -22,6 +23,7 @@ public class MatchingStartService {
     private final ParticipantGeoStore geoStore;
     private final MemberService memberService;
     private final MatchingService matchingService;
+    private final CategoryQueueStore categoryQueueStore;
 
     public void startMatching(double lat, double lng, MatchingCategory category, int participantCount, Long memberId) {
         validateExistParticipating(memberId);
@@ -36,6 +38,8 @@ public class MatchingStartService {
         );
 
         geoStore.addUserLocation(memberId, lng, lat);
+        participantStore.transitionToParticipating(memberId);
+        categoryQueueStore.addToQueue(category, participantCount, memberId);
     }
 
     private void deducePoint(Long memberId) {

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/service/MatchingStartService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/service/MatchingStartService.java
@@ -5,7 +5,7 @@ import com.mokakbob.domain.matching.domain.vo.MatchingCategory;
 import com.mokakbob.domain.matching.service.MatchingService;
 import com.mokakbob.domain.member.domain.Member;
 import com.mokakbob.domain.member.service.MemberService;
-import com.mokakbob.matching.config.KafkaTopics;
+import com.mokakbob.matching.constant.KafkaTopics;
 import com.mokakbob.matching.domain.CategoryQueueStore;
 import com.mokakbob.matching.domain.ParticipantGeoStore;
 import com.mokakbob.matching.exception.MatchingErrorCode;
@@ -33,6 +33,7 @@ public class MatchingStartService {
     @Transactional
     public void participateMatching(double lat, double lng, MatchingCategory category, int participantCount,
                                     Long memberId) {
+        participantStore.clearAll(memberId);
         validateExistParticipating(memberId);
         deducePoint(memberId);
 

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/service/MatchingStartService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/service/MatchingStartService.java
@@ -1,0 +1,7 @@
+package com.mokakbob.matching.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class MatchingStartService {
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/service/MatchingStartService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/service/MatchingStartService.java
@@ -1,7 +1,12 @@
 package com.mokakbob.matching.service;
 
+import com.mokakbob.domain.matching.domain.vo.MatchingCategory;
 import org.springframework.stereotype.Service;
 
 @Service
 public class MatchingStartService {
+
+    public void startMatching(double lat, double lng, MatchingCategory category, int participantCount, Long memberId) {
+
+    }
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/service/MatchingStartService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/service/MatchingStartService.java
@@ -5,13 +5,17 @@ import com.mokakbob.domain.matching.domain.vo.MatchingCategory;
 import com.mokakbob.domain.matching.service.MatchingService;
 import com.mokakbob.domain.member.domain.Member;
 import com.mokakbob.domain.member.service.MemberService;
+import com.mokakbob.matching.config.KafkaTopics;
 import com.mokakbob.matching.domain.CategoryQueueStore;
 import com.mokakbob.matching.domain.ParticipantGeoStore;
 import com.mokakbob.matching.exception.MatchingErrorCode;
 import com.mokakbob.matching.infrastructure.ParticipantRedisStore;
+import com.mokakbob.matching.service.event.MatchingParticipateEvent;
 import java.math.BigDecimal;
 import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -24,22 +28,23 @@ public class MatchingStartService {
     private final MemberService memberService;
     private final MatchingService matchingService;
     private final CategoryQueueStore categoryQueueStore;
+    private final KafkaTemplate<String, Object> kafkaTemplate;
 
-    public void startMatching(double lat, double lng, MatchingCategory category, int participantCount, Long memberId) {
+    @Transactional
+    public void participateMatching(double lat, double lng, MatchingCategory category, int participantCount,
+                                    Long memberId) {
         validateExistParticipating(memberId);
         deducePoint(memberId);
 
-        matchingService.saveMatchingRequest(
-                memberId,
-                category,
-                participantCount,
-                new BigDecimal(lat),
-                new BigDecimal(lng)
-        );
+        matchingService.saveMatchingRequest(memberId, category, participantCount, new BigDecimal(lat),
+                new BigDecimal(lng));
 
         geoStore.addUserLocation(memberId, lng, lat);
         participantStore.transitionToParticipating(memberId);
         categoryQueueStore.addToQueue(category, participantCount, memberId);
+
+        MatchingParticipateEvent event = new MatchingParticipateEvent(memberId, lat, lng, category, participantCount);
+        kafkaTemplate.send(KafkaTopics.MATCHING_PARTICIPATE, event);
     }
 
     private void deducePoint(Long memberId) {
@@ -48,7 +53,7 @@ public class MatchingStartService {
     }
 
     private void validateExistParticipating(Long memberId) {
-        if(participantStore.isAlreadyParticipating(memberId)) {
+        if (participantStore.isAlreadyParticipating(memberId)) {
             throw new ApiException(MatchingErrorCode.EXIST_MATCHING);
         }
     }

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/service/MatchingStartService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/service/MatchingStartService.java
@@ -6,7 +6,7 @@ import com.mokakbob.domain.matching.service.MatchingService;
 import com.mokakbob.domain.member.domain.Member;
 import com.mokakbob.domain.member.service.MemberService;
 import com.mokakbob.matching.exception.MatchingErrorCode;
-import com.mokakbob.matching.infrastructure.MatchingParticipantStore;
+import com.mokakbob.matching.infrastructure.ParticipantRedisStore;
 import java.math.BigDecimal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,7 +17,7 @@ public class MatchingStartService {
 
     private static final int DEFAULT_DEDUCE_POINT = 2000;
 
-    private final MatchingParticipantStore participantStore;
+    private final ParticipantRedisStore participantStore;
     private final MemberService memberService;
     private final MatchingService matchingService;
 

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/service/event/MatchingParticipateEvent.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/service/event/MatchingParticipateEvent.java
@@ -1,0 +1,12 @@
+package com.mokakbob.matching.service.event;
+
+import com.mokakbob.domain.matching.domain.vo.MatchingCategory;
+
+public record MatchingParticipateEvent(
+        Long memberId,
+        double lat,
+        double lng,
+        MatchingCategory category,
+        int participantCount
+) {
+}

--- a/mokakbob-api/src/main/resources/application.yml
+++ b/mokakbob-api/src/main/resources/application.yml
@@ -1,3 +1,8 @@
 spring:
   profiles:
     active: local
+
+  kafka:
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer

--- a/mokakbob-api/src/test/java/com/mokakbob/matching/service/MatchingStartServiceTest.java
+++ b/mokakbob-api/src/test/java/com/mokakbob/matching/service/MatchingStartServiceTest.java
@@ -9,7 +9,7 @@ import com.mokakbob.domain.matching.domain.vo.MatchingCategory;
 import com.mokakbob.domain.matching.service.MatchingService;
 import com.mokakbob.domain.member.domain.Member;
 import com.mokakbob.domain.member.service.MemberService;
-import com.mokakbob.matching.config.KafkaTopics;
+import com.mokakbob.matching.constant.KafkaTopics;
 import com.mokakbob.matching.domain.CategoryQueueStore;
 import com.mokakbob.matching.domain.ParticipantGeoStore;
 import com.mokakbob.matching.infrastructure.ParticipantRedisStore;

--- a/mokakbob-api/src/test/java/com/mokakbob/matching/service/MatchingStartServiceTest.java
+++ b/mokakbob-api/src/test/java/com/mokakbob/matching/service/MatchingStartServiceTest.java
@@ -1,0 +1,76 @@
+package com.mokakbob.matching.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.mokakbob.domain.matching.domain.vo.MatchingCategory;
+import com.mokakbob.domain.matching.service.MatchingService;
+import com.mokakbob.domain.member.domain.Member;
+import com.mokakbob.domain.member.service.MemberService;
+import com.mokakbob.matching.config.KafkaTopics;
+import com.mokakbob.matching.domain.CategoryQueueStore;
+import com.mokakbob.matching.domain.ParticipantGeoStore;
+import com.mokakbob.matching.infrastructure.ParticipantRedisStore;
+import com.mokakbob.matching.service.event.MatchingParticipateEvent;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaTemplate;
+
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("NonAsciiCharacters")
+class MatchingStartServiceTest {
+
+    @InjectMocks
+    private MatchingStartService matchingStartService;
+
+    @Mock
+    private ParticipantRedisStore participantStore;
+
+    @Mock
+    private ParticipantGeoStore geoStore;
+
+    @Mock
+    private MemberService memberService;
+
+    @Mock
+    private MatchingService matchingService;
+
+    @Mock
+    private CategoryQueueStore categoryQueueStore;
+
+    @Mock
+    private KafkaTemplate<String, Object> kafkaTemplate;
+
+    @Test
+    void 매칭_참여_정상_흐름_테스트() {
+        // given
+        Long memberId = 1L;
+        double lat = 37.5;
+        double lng = 127.0;
+        MatchingCategory category = MatchingCategory.CHINESE;
+        int participantCount = 2;
+        Member fakeMember = Member.builder()
+                .depositPoint(5000)
+                .build();
+
+        given(participantStore.isAlreadyParticipating(memberId)).willReturn(false);
+        given(memberService.findMember(memberId)).willReturn(fakeMember);
+
+        // when
+        matchingStartService.participateMatching(lat, lng, category, participantCount, memberId);
+
+        // then
+        verify(participantStore).isAlreadyParticipating(memberId);
+        verify(memberService).findMember(memberId);
+        verify(matchingService).saveMatchingRequest(eq(memberId), eq(category), eq(participantCount), any(), any());
+        verify(geoStore).addUserLocation(memberId, lng, lat);
+        verify(participantStore).transitionToParticipating(memberId);
+        verify(categoryQueueStore).addToQueue(category, participantCount, memberId);
+        verify(kafkaTemplate).send(eq(KafkaTopics.MATCHING_PARTICIPATE), any(MatchingParticipateEvent.class));
+    }
+}

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/matching/domain/MatchingRequest.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/matching/domain/MatchingRequest.java
@@ -12,12 +12,16 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import java.math.BigDecimal;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor
 public class MatchingRequest extends BaseEntity {
 
     @Id

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/matching/domain/MatchingRequest.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/matching/domain/MatchingRequest.java
@@ -1,6 +1,7 @@
 package com.mokakbob.domain.matching.domain;
 
 import com.mokakbob.common.domain.BaseEntity;
+import com.mokakbob.domain.matching.domain.vo.MatchingCategory;
 import com.mokakbob.domain.matching.domain.vo.MatchingRequestStatus;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -26,8 +27,9 @@ public class MatchingRequest extends BaseEntity {
     @Column(nullable = false)
     private Long memberId;
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private String menuCategory;
+    private MatchingCategory matchingCategory;
 
     @Column(nullable = false)
     private Integer groupSize;

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/matching/domain/vo/MatchingCategory.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/matching/domain/vo/MatchingCategory.java
@@ -1,0 +1,18 @@
+package com.mokakbob.domain.matching.domain.vo;
+
+import lombok.Getter;
+
+@Getter
+public enum MatchingCategory {
+
+    KOREAN("한식"),
+    JAPANESE("일식"),
+    CHINESE("중식"),
+    WESTERN("양식");
+
+    private final String displayName;
+
+    MatchingCategory(String displayName) {
+        this.displayName = displayName;
+    }
+}

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/matching/domain/vo/MatchingRequestStatus.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/matching/domain/vo/MatchingRequestStatus.java
@@ -2,6 +2,7 @@ package com.mokakbob.domain.matching.domain.vo;
 
 public enum MatchingRequestStatus {
 
+    NONE,
     PARTICIPATE,
     FOUND,
     REJECTED,

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/matching/domain/vo/MatchingRequestStatus.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/matching/domain/vo/MatchingRequestStatus.java
@@ -2,8 +2,9 @@ package com.mokakbob.domain.matching.domain.vo;
 
 public enum MatchingRequestStatus {
 
-    WAITING,
-    MATCHED,
+    PARTICIPATE,
+    FOUND,
+    REJECTED,
     CANCELED,
     EXPIRED
 }

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/matching/service/MatchingService.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/matching/service/MatchingService.java
@@ -1,7 +1,31 @@
 package com.mokakbob.domain.matching.service;
 
+import com.mokakbob.domain.matching.domain.MatchingRequest;
+import com.mokakbob.domain.matching.domain.vo.MatchingCategory;
+import com.mokakbob.domain.matching.domain.vo.MatchingRequestStatus;
+import com.mokakbob.domain.matching.repository.MatchingRequestRepository;
+import java.math.BigDecimal;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@RequiredArgsConstructor
 public class MatchingService {
+
+    private final MatchingRequestRepository requestRepository;
+
+    @Transactional
+    public void saveMatchingRequest(Long memberId, MatchingCategory category, int groupSize, BigDecimal lat, BigDecimal lng) {
+        MatchingRequest matchingRequest = MatchingRequest.builder()
+                .memberId(memberId)
+                .matchingCategory(category)
+                .groupSize(groupSize)
+                .latitude(lat)
+                .longitude(lng)
+                .status(MatchingRequestStatus.PARTICIPATE)
+                .build();
+
+        requestRepository.save(matchingRequest);
+    }
 }

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/member/domain/Member.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/member/domain/Member.java
@@ -53,4 +53,8 @@ public class Member extends BaseEntity {
     public void updateProfileImage(String newProfile) {
         this.profileImage = newProfile;
     }
+
+    public void deductPoint(int point) {
+        this.depositPoint -= point;
+    }
 }

--- a/mokakbob-redis/src/main/java/com/mokakbob/config/RedisTemplateConfig.java
+++ b/mokakbob-redis/src/main/java/com/mokakbob/config/RedisTemplateConfig.java
@@ -10,7 +10,7 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 public class RedisTemplateConfig {
 
     @Bean
-    public RedisTemplate<String, String> authRedisTemplate(RedisConnectionFactory redisConnectionFactory) {
+    public RedisTemplate<String, String> basicRedisTemplate(RedisConnectionFactory redisConnectionFactory) {
         RedisTemplate<String, String> template = new RedisTemplate<>();
         template.setConnectionFactory(redisConnectionFactory);
 


### PR DESCRIPTION
## 관련 이슈 번호
#36 closed 

## 작업 내용 25.08.07

### 동시성 + 원자성 + 트랜잭션 범위의 문제
~~~
@Transactional
    public void participateMatching
~~~
1. 코드 리뷰를 통해 해당 메서드의 원자성이 보장되지 않음 + 트랜잭션 범위가 너무 넓다는 것을 확인했습니다.
  * 이에 따라 도메인(Member) 중심으로 트랜잭션이 적용되게 하였고, Kafka와 Redis의 행위는 트랜잭션 커밋 이후 별도의 이벤트 리스너를 통해 처리되도록 분리하였습니다. 
  * 하지만 이러한 변경 사항에도, `Kafka 토픽 발급 실패 문제`, `Redis 상태 업데이트 및 생성 실패` 문제가 남아있다는 것을 인지했습니다.
    * 어떻게 해결할지는 추후에 공부하고 공유드리겠습니다!
    * 추가로 해당 사항은 다음 PR 에 반영해보도록 하겠습니다.



2. 해당 메서드를 호출하였을 때 동시성 문제가 생길 수 있다는 것을 확인했습니다.
  * DB 차원에서 락을 걸 예정입니다. -> 어떤 락을 걸 것인지는 학습해보겠습니다.
  * Redis 의 경우 `Redisson` 라이브러리를 통해 분산 락 구현 예정입니다.
  * 카프카 : Producer 측은 설정을 통해 메시지 중복 방지 + 순서 보장을 적용했지만 Consumer 쪽에서도 추가 설정을 통해 동시성 문제를 방지해야 할 것 같습니다. 이 부분은 Consumer 구현하면서 적용해보겠습니다.


## 작업 내용 25.08.06

### 3단계 Redis 상태 관리
* Redis 를 크게 3개로 나누어 관리했습니다.


1. 유저 위치 거리 정보 관리 `geoRedisStore`
  * 해당 구현체에서는 유저의 위치 정보(위도/경도 좌표)를 저장합니다.

2. 유저 상태 관리 `ParticipantRedisStore`
  * 해당 구현체에서는 유저의 매칭 상태를 관리합니다.
  * 상태 전이(참여 → 매칭 중 등)를 반영하는 메서드를 제공하고, 중복 참여를 방지합니다.

4. 카테고리 - 요청 인원 관리 `CategoryQueueRedisStore`
  * 해당 구현체가 실질적인 대기열 관리를 담당합니다.
  * [음식 카테고리와 같이 먹고 싶은 인원 수]를 키로 관리하기에 해당 저장소에서 자연스럽게 1차 필터링 후 나머지 필터링을 진행하도록 할 예정입니다.

### 도커
* 현재 로컬 개발환경에서는 도커로 레디스와 카프카를 같이 띄워 관리합니다.
* 해당 api 테스트 시, 카프카 토픽 존재 유무와 레디스 상태 확인하였습니다.

### 카프카 
* 멱등성 보장을 위한 설정, 재전송 설정 등 설정 하나 하나 찾아보고 적용하였습니다.

## 참고사항 
* 변경 파일이 많아서 커밋 단위로 보시면 편할 것 같습니다!

## 질문 사항
* 현재 api 모듈에 RedisStore 인터페이스와 구현체를 모두 두었는데, Consumer 모듈에서 동일한 RedisStore를 사용하게 될 것 같습니다. 그래서 RedisStore 인터페이스는 Core - repository 계층에 두고(공유되는 인터페이스) 구현체는 Redis 모듈에서 따로 관리하고자 하는데 어떻게 생각하시나요?? 다른 좋은 분리 방안이 있을까요??

* 카프카 토픽 발급은 이전 트랜잭션이 진행되고 난 후, 트랜잭션리스너를 통해 추후에 토픽 던지도록 하는 것이 나을까요?? 이전 트랜잭션에서 문제가 생겼는데 카프카는 이미 토픽 던지고 나면 이 부분 문제가 있을 것 같습니다.