### PR TITLE
#43 [Feat] 카프카 토픽 수동 재발급 로직 구현

### DIFF
--- a/mokakbob-api/src/main/java/com/mokakbob/admin/controller/AdminKafkaController.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/admin/controller/AdminKafkaController.java
@@ -1,0 +1,32 @@
+package com.mokakbob.admin.controller;
+
+import com.mokakbob.admin.controller.request.KafkaResendRequest;
+import com.mokakbob.admin.service.AdminKafkaService;
+import com.mokakbob.common.path.admin.AdminKafkaPath;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AdminKafkaController {
+
+    private final AdminKafkaService adminKafkaService;
+
+    @PostMapping(AdminKafkaPath.RESEND)
+    public ResponseEntity<Void> resendTopic(@RequestBody KafkaResendRequest request) {
+        adminKafkaService.resendParticipateTopic(
+                request.key(),
+                request.memberId(),
+                request.lat(),
+                request.lng(),
+                request.category(),
+                request.participantCount()
+        );
+
+        return ResponseEntity.ok()
+                .build();
+    }
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/admin/controller/request/KafkaResendRequest.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/admin/controller/request/KafkaResendRequest.java
@@ -1,0 +1,26 @@
+package com.mokakbob.admin.controller.request;
+
+import com.mokakbob.domain.matching.domain.vo.MatchingCategory;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record KafkaResendRequest(
+        @NotBlank
+        String key,
+
+        @NotBlank
+        Long memberId,
+
+        @NotBlank
+        double lat,
+
+        @NotBlank
+        double lng,
+
+        @NotNull
+        MatchingCategory category,
+
+        @NotBlank
+        int participantCount
+) {
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/admin/service/AdminKafkaService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/admin/service/AdminKafkaService.java
@@ -1,0 +1,37 @@
+package com.mokakbob.admin.service;
+
+import com.mokakbob.domain.matching.domain.vo.MatchingCategory;
+import com.mokakbob.matching.service.event.MatchingParticipateEvent;
+import com.mokakbob.topic.KafkaTopic;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AdminKafkaService {
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    public void resendParticipateTopic(String key, Long memberId, double lat, double lng, MatchingCategory category, int participantCount) {
+        MatchingParticipateEvent event = new MatchingParticipateEvent(
+              memberId, lat, lng, category, participantCount
+        );
+
+        try {
+            kafkaTemplate.send(KafkaTopic.MATCHING_PARTICIPATE.getTopicName(), key, event);
+        } catch (Exception e) {
+            log.error("카프카 토픽 재발급 실패: {}\n실패한 이벤트: {}\n재처리 필요 정보 - memberId: {}, key: {}, lat: {}, lng: {}, category: {}, participantCount: {}",
+                    e.getMessage(),
+                    event,
+                    event.memberId(),
+                    event.memberId(),
+                    event.lat(),
+                    event.lng(),
+                    event.category(),
+                    event.participantCount());
+        }
+    }
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/config/SecurityConfig.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/config/SecurityConfig.java
@@ -52,6 +52,7 @@ public class SecurityConfig {
                         .requestMatchers(
                                 PermitPath.AUTH_BASE + WILD_CARD_PATH,          // 일반 회원가입
                                 PermitPath.EMAIL_BASE + WILD_CARD_PATH,        // 이메일 인증
+                                PermitPath.ADMIN_BASE + WILD_CARD_PATH,        // admin
                                 "/login/oauth2/**",                         // Oauth 콜백 URI
                                 "/favicon.ico",
                                 "/error"

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/filter/JwtAuthenticationFilter.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/filter/JwtAuthenticationFilter.java
@@ -41,7 +41,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String uri = request.getRequestURI();
 
         return uri.startsWith(PermitPath.AUTH_BASE) ||
-                uri.startsWith(PermitPath.EMAIL_BASE)
+                uri.startsWith(PermitPath.EMAIL_BASE) ||
+                uri.startsWith(PermitPath.ADMIN_BASE)
                 ;
     }
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/common/path/admin/AdminKafkaPath.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/common/path/admin/AdminKafkaPath.java
@@ -1,0 +1,6 @@
+package com.mokakbob.common.path.admin;
+
+public class AdminKafkaPath {
+
+    public static final String RESEND = "/api/v1/admin/kafka/retry";
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/common/path/permit/PermitPath.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/common/path/permit/PermitPath.java
@@ -4,4 +4,5 @@ public class PermitPath {
 
     public static final String EMAIL_BASE = "/api/v1/email";
     public static final String AUTH_BASE = "/api/v1/auth";
+    public static final String ADMIN_BASE = "/api/v1/admin";
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/listener/MatchingParticipateEventListener.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/listener/MatchingParticipateEventListener.java
@@ -32,15 +32,16 @@ public class MatchingParticipateEventListener {
     }
 
     private void sendKafkaTopic(MatchingParticipateEvent event) {
+        String idempotencyKey = generateIdempotencyKey(String.valueOf(event.memberId()));
+
         try {
-            String idempotencyKey = generateIdempotencyKey(String.valueOf(event.memberId()));
             kafkaTemplate.send(KafkaTopic.MATCHING_PARTICIPATE.getTopicName(), idempotencyKey, event);
         } catch (Exception e) {
             log.error("카프카 토픽 발급 실패: {}\n실패한 이벤트: {}\n재처리 필요 정보 - memberId: {}, key: {}, lat: {}, lng: {}, category: {}, participantCount: {}",
                     e.getMessage(),
                     event,
                     event.memberId(),
-                    event.memberId(),
+                    idempotencyKey,
                     event.lat(),
                     event.lng(),
                     event.category(),


### PR DESCRIPTION
## 관련 이슈 번호
#43 closed

## 작업 내용 25.08.11
* 카프카에서 메시지가 실패할 경우, 이를 수동으로 재발송할 수 있도록 기능을 추가했습니다.
* 관리자가 실패한 메시지를 다시 보낼 수 있는 API를 구현하여, 재전송 기능을 구현하였습니다.
* Admin 경로에 한하여 filter 와 security 인가 경로를 풀어두었는데, 추후에 Role 에 따른 권한 부여 구현해보도록 하겠습니다.