### PR TITLE
#45 [FEAT] Redis 장애 발생을 대비한 재시도 로직 및 Master-Slave 구성 적용

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,24 @@
-version: '3.8'
-
 services:
-  redis:
+  redis-master:
     image: redis:7.2
-    container_name: redis
+    container_name: redis-master
     ports:
       - "6379:6379"
     volumes:
-      - redis-data:/data
+      - redis-master-data:/data
     restart: always
+
+  redis-slave:
+    image: redis:7.2
+    container_name: redis-slave
+    ports:
+      - "6380:6379"
+    volumes:
+      - redis-slave-data:/data
+    restart: always
+    depends_on:
+      - redis-master
+    command: ["redis-server", "--replicaof", "redis-master", "6379"]
 
   zookeeper:
     image: confluentinc/cp-zookeeper:7.5.0
@@ -22,6 +32,7 @@ services:
 
   kafka:
     image: confluentinc/cp-kafka:7.5.0
+    container_name: kafka
     ports:
       - "9092:9092"
     environment:
@@ -36,4 +47,6 @@ services:
     restart: always
 
 volumes:
+  redis-master-data:
+  redis-slave-data:
   redis-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,23 +2,75 @@ services:
   redis-master:
     image: redis:7.2
     container_name: redis-master
-    ports:
-      - "6379:6379"
+    ports: [ "6379:6379" ]
     volumes:
       - redis-master-data:/data
     restart: always
+    healthcheck:
+      test: [ "CMD", "redis-cli", "ping" ]
+      interval: 2s
+      timeout: 1s
+      retries: 20
 
   redis-slave:
     image: redis:7.2
     container_name: redis-slave
-    ports:
-      - "6380:6379"
+    ports: [ "6380:6379" ]
     volumes:
       - redis-slave-data:/data
     restart: always
     depends_on:
-      - redis-master
-    command: ["redis-server", "--replicaof", "redis-master", "6379"]
+      redis-master:
+        condition: service_healthy
+    command: [ "redis-server", "--replicaof", "redis-master", "6379" ]
+    healthcheck:
+      test: [ "CMD", "redis-cli", "-p", "6379", "ping" ]
+      interval: 2s
+      timeout: 1s
+      retries: 20
+
+  sentinel-1:
+    image: redis:7.2
+    container_name: sentinel-1
+    ports: [ "26379:26379" ]
+    volumes:
+      - ./sentinel/sentinel-1.conf:/etc/redis/sentinel-1.conf
+    command: [ "redis-sentinel", "/etc/redis/sentinel-1.conf" ]
+    depends_on:
+      redis-master:
+        condition: service_healthy
+      redis-slave:
+        condition: service_started
+    restart: always
+
+  sentinel-2:
+    image: redis:7.2
+    container_name: sentinel-2
+    ports: [ "26380:26379" ]
+    volumes:
+      - ./sentinel/sentinel-2.conf:/etc/redis/sentinel-2.conf
+    command: [ "redis-sentinel", "/etc/redis/sentinel-2.conf" ]
+    depends_on:
+      redis-master:
+        condition: service_healthy
+      redis-slave:
+        condition: service_started
+    restart: always
+
+  sentinel-3:
+    image: redis:7.2
+    container_name: sentinel-3
+    ports: [ "26381:26379" ]
+    volumes:
+      - ./sentinel/sentinel-3.conf:/etc/redis/sentinel-3.conf
+    command: [ "redis-sentinel", "/etc/redis/sentinel-3.conf" ]
+    depends_on:
+      redis-master:
+        condition: service_healthy
+      redis-slave:
+        condition: service_started
+    restart: always
+
 
   zookeeper:
     image: confluentinc/cp-zookeeper:7.5.0
@@ -49,4 +101,3 @@ services:
 volumes:
   redis-master-data:
   redis-slave-data:
-  redis-data:

--- a/mokakbob-api/src/main/java/com/mokakbob/common/config/RetryConfig.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/common/config/RetryConfig.java
@@ -1,4 +1,4 @@
-package com.mokakbob.auth.config;
+package com.mokakbob.common.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.retry.annotation.EnableRetry;

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/annotation/RedisRetryable.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/annotation/RedisRetryable.java
@@ -1,0 +1,19 @@
+package com.mokakbob.matching.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.data.redis.RedisConnectionFailureException;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Retryable(
+        retryFor = RedisConnectionFailureException.class,
+        maxAttempts = 5,
+        backoff = @Backoff(delay = 2000)
+)
+public @interface RedisRetryable {
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/listener/MatchingParticipateEventListener.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/listener/MatchingParticipateEventListener.java
@@ -28,7 +28,10 @@ public class MatchingParticipateEventListener {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleMatchingParticipateEvent(MatchingParticipateEvent event) {
         sendKafkaTopic(event);
-        saveMatchingParticipateEvent(event);
+
+        saveParticipantInfo(event);
+        saveGeo(event);
+        saveQueue(event);
     }
 
     @Retryable(
@@ -36,9 +39,25 @@ public class MatchingParticipateEventListener {
             maxAttempts = 5,
             backoff = @Backoff(delay = 2000)
     )
-    private void saveMatchingParticipateEvent(MatchingParticipateEvent event) {
+    private void saveParticipantInfo(MatchingParticipateEvent event) {
         participantStore.transitionToParticipating(event.memberId());
+    }
+
+    @Retryable(
+            retryFor = RedisConnectionFailureException.class,
+            maxAttempts = 5,
+            backoff = @Backoff(delay = 2000)
+    )
+    private void saveGeo(MatchingParticipateEvent event) {
         geoStore.addMemberLocation(event.memberId(), event.lng(), event.lat());
+    }
+
+    @Retryable(
+            retryFor = RedisConnectionFailureException.class,
+            maxAttempts = 5,
+            backoff = @Backoff(delay = 2000)
+    )
+    private void saveQueue(MatchingParticipateEvent event) {
         categoryQueueStore.addToQueue(event.category(), event.participantCount(), event.memberId());
     }
 

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/listener/MatchingParticipateEventListener.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/listener/MatchingParticipateEventListener.java
@@ -7,7 +7,10 @@ import com.mokakbob.topic.KafkaTopic;
 import com.mokakbob.matching.service.event.MatchingParticipateEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.RedisConnectionFailureException;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -25,7 +28,15 @@ public class MatchingParticipateEventListener {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleMatchingParticipateEvent(MatchingParticipateEvent event) {
         sendKafkaTopic(event);
+        saveMatchingParticipateEvent(event);
+    }
 
+    @Retryable(
+            retryFor = RedisConnectionFailureException.class,
+            maxAttempts = 5,
+            backoff = @Backoff(delay = 2000)
+    )
+    private void saveMatchingParticipateEvent(MatchingParticipateEvent event) {
         participantStore.transitionToParticipating(event.memberId());
         geoStore.addMemberLocation(event.memberId(), event.lng(), event.lat());
         categoryQueueStore.addToQueue(event.category(), event.participantCount(), event.memberId());

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/listener/MatchingParticipateEventListener.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/listener/MatchingParticipateEventListener.java
@@ -1,9 +1,6 @@
 package com.mokakbob.matching.listener;
 
-import com.mokakbob.cache.CategoryQueueStore;
-import com.mokakbob.cache.ParticipantGeoStore;
-import com.mokakbob.cache.ParticipantStore;
-import com.mokakbob.matching.annotation.RedisRetryable;
+import com.mokakbob.matching.service.MatchingWriterService;
 import com.mokakbob.topic.KafkaTopic;
 import com.mokakbob.matching.service.event.MatchingParticipateEvent;
 import lombok.RequiredArgsConstructor;
@@ -18,33 +15,16 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @Slf4j
 public class MatchingParticipateEventListener {
 
-    private final ParticipantStore participantStore;
-    private final ParticipantGeoStore geoStore;
-    private final CategoryQueueStore categoryQueueStore;
     private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final MatchingWriterService matchingWriterService;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleMatchingParticipateEvent(MatchingParticipateEvent event) {
         sendKafkaTopic(event);
 
-        saveParticipantInfo(event);
-        saveGeo(event);
-        saveQueue(event);
-    }
-
-    @RedisRetryable
-    private void saveParticipantInfo(MatchingParticipateEvent event) {
-        participantStore.transitionToParticipating(event.memberId());
-    }
-
-    @RedisRetryable
-    private void saveGeo(MatchingParticipateEvent event) {
-        geoStore.addMemberLocation(event.memberId(), event.lng(), event.lat());
-    }
-
-    @RedisRetryable
-    private void saveQueue(MatchingParticipateEvent event) {
-        categoryQueueStore.addToQueue(event.category(), event.participantCount(), event.memberId());
+        matchingWriterService.saveParticipantInfo(event);
+        matchingWriterService.saveGeo(event);
+        matchingWriterService.saveQueue(event);
     }
 
     private void sendKafkaTopic(MatchingParticipateEvent event) {

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/listener/MatchingParticipateEventListener.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/listener/MatchingParticipateEventListener.java
@@ -3,14 +3,12 @@ package com.mokakbob.matching.listener;
 import com.mokakbob.cache.CategoryQueueStore;
 import com.mokakbob.cache.ParticipantGeoStore;
 import com.mokakbob.cache.ParticipantStore;
+import com.mokakbob.matching.annotation.RedisRetryable;
 import com.mokakbob.topic.KafkaTopic;
 import com.mokakbob.matching.service.event.MatchingParticipateEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.RedisConnectionFailureException;
 import org.springframework.kafka.core.KafkaTemplate;
-import org.springframework.retry.annotation.Backoff;
-import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -34,29 +32,17 @@ public class MatchingParticipateEventListener {
         saveQueue(event);
     }
 
-    @Retryable(
-            retryFor = RedisConnectionFailureException.class,
-            maxAttempts = 5,
-            backoff = @Backoff(delay = 2000)
-    )
+    @RedisRetryable
     private void saveParticipantInfo(MatchingParticipateEvent event) {
         participantStore.transitionToParticipating(event.memberId());
     }
 
-    @Retryable(
-            retryFor = RedisConnectionFailureException.class,
-            maxAttempts = 5,
-            backoff = @Backoff(delay = 2000)
-    )
+    @RedisRetryable
     private void saveGeo(MatchingParticipateEvent event) {
         geoStore.addMemberLocation(event.memberId(), event.lng(), event.lat());
     }
 
-    @Retryable(
-            retryFor = RedisConnectionFailureException.class,
-            maxAttempts = 5,
-            backoff = @Backoff(delay = 2000)
-    )
+    @RedisRetryable
     private void saveQueue(MatchingParticipateEvent event) {
         categoryQueueStore.addToQueue(event.category(), event.participantCount(), event.memberId());
     }

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/service/MatchingWriterService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/service/MatchingWriterService.java
@@ -1,0 +1,33 @@
+package com.mokakbob.matching.service;
+
+import com.mokakbob.cache.CategoryQueueStore;
+import com.mokakbob.cache.ParticipantGeoStore;
+import com.mokakbob.cache.ParticipantStore;
+import com.mokakbob.matching.annotation.RedisRetryable;
+import com.mokakbob.matching.service.event.MatchingParticipateEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MatchingWriterService {
+
+    private final ParticipantStore participantStore;
+    private final ParticipantGeoStore geoStore;
+    private final CategoryQueueStore categoryQueueStore;
+
+    @RedisRetryable
+    public void saveParticipantInfo(MatchingParticipateEvent event) {
+        participantStore.transitionToParticipating(event.memberId());
+    }
+
+    @RedisRetryable
+    public void saveGeo(MatchingParticipateEvent event) {
+        geoStore.addMemberLocation(event.memberId(), event.lng(), event.lat());
+    }
+
+    @RedisRetryable
+    public void saveQueue(MatchingParticipateEvent event) {
+        categoryQueueStore.addToQueue(event.category(), event.participantCount(), event.memberId());
+    }
+}

--- a/mokakbob-api/src/main/resources/application.yml
+++ b/mokakbob-api/src/main/resources/application.yml
@@ -6,3 +6,12 @@ spring:
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+
+  data:
+    redis:
+      sentinel:
+        master: mymaster
+        nodes:
+          - localhost:26379
+          - localhost:26380
+          - localhost:26381

--- a/mokakbob-redis/src/main/java/com/mokakbob/config/RedisConfig.java
+++ b/mokakbob-redis/src/main/java/com/mokakbob/config/RedisConfig.java
@@ -1,0 +1,31 @@
+package com.mokakbob.config;
+
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisSentinelConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.redis.sentinel.master}")
+    private String master;
+
+    @Value("${spring.redis.sentinel.nodes}")
+    private List<String> sentinelNodes;
+
+    @Bean
+    public LettuceConnectionFactory redisConnectionFactory() {
+        RedisSentinelConfiguration sentinelConfig = new RedisSentinelConfiguration()
+                .master(master);
+
+        for (String node : sentinelNodes) {
+            String[] parts = node.split(":");
+            sentinelConfig.sentinel(parts[0], Integer.parseInt(parts[1]));
+        }
+
+        return new LettuceConnectionFactory(sentinelConfig);
+    }
+}

--- a/sentinel/sentinel-1.conf
+++ b/sentinel/sentinel-1.conf
@@ -1,0 +1,10 @@
+port 26379
+bind 0.0.0.0
+dir /tmp
+logfile "sentinel-1.log"
+
+sentinel resolve-hostnames yes
+sentinel monitor mymaster redis-master 6379 2
+sentinel down-after-milliseconds mymaster 5000
+sentinel failover-timeout mymaster 60000
+sentinel parallel-syncs mymaster 1

--- a/sentinel/sentinel-2.conf
+++ b/sentinel/sentinel-2.conf
@@ -1,0 +1,10 @@
+port 26379
+bind 0.0.0.0
+dir /tmp
+logfile "sentinel-2.log"
+
+sentinel resolve-hostnames yes
+sentinel monitor mymaster redis-master 6379 2
+sentinel down-after-milliseconds mymaster 5000
+sentinel failover-timeout mymaster 60000
+sentinel parallel-syncs mymaster 1

--- a/sentinel/sentinel-3.conf
+++ b/sentinel/sentinel-3.conf
@@ -1,0 +1,10 @@
+port 26379
+bind 0.0.0.0
+dir /tmp
+logfile "sentinel-3.log"
+
+sentinel resolve-hostnames yes
+sentinel monitor mymaster redis-master 6379 2
+sentinel down-after-milliseconds mymaster 5000
+sentinel failover-timeout mymaster 60000
+sentinel parallel-syncs mymaster 1


### PR DESCRIPTION
## 관련 이슈 번호
#45 closed

## 작업 내용 25.08.14
* Redis 재처리 로직 및 Master-Slave 구조 적용

### Redis Retry 범위
* 처음 Redis Retry 를 구현할 때, 
~~~
saveParticipantInfo(event);
saveGeo(event);
saveQueue(event);
~~~
 해당 세 로직을 한번에 묶어 retry 적용하였습니다.

* 하지만 하나라도 오류 날 시, 모두 재처리 해야 하기 때문에 scope 를 하나의 로직 단위로 줄여 retry 적용하였습니다.
  * 적용하는 과정에서 `@Retry` 어노테이션 + 설정들이 중복되는 상황이 있어, `@RedisRetryable` 어노테이션을 생성하여 적용하였습니다.


### Redis Master - Slave 구조 적용
* Master 1 + Slave 1 구조로 구성했습니다.
  * 목적은 데이터 백업용이고, 서비스 규모상 읽기 분산 은 불필요하다고 판단하여 Slave는 1대만 두었습니다.
  * Master → Slave 단방향 동기화가 이루어지며, Slave 인스턴스는 Master 장애 발생 시 서로 바뀔 수 있도록 설정하였습니다.(sentinel을 통해)
* failover 자동 처리를 위해 `Sentinel`을 구성하였습니다.
  * `Sentinel` 노드 중 2개 이상이 Master 장애를 감지하면 해당 Master를 장애로 판정하고, Slave 중 하나를 자동으로 승격시키도록 설정하였습니다.(Sentinel 노드는 총 3개)
  
  
  ++ 도커로 sentinel 올린 후에, redis master-slave 구조 잘 연결되었는지(읽기 쓰기 확인), sentienl 장애 감지 및 failover, failover 후 재동기화 테스트 진행했고 이상 없었습니다!