### PR TITLE
#47 [FEAT] 매칭 참가 기능 동시성 문제 해결을 위한 로직 구현

### DIFF
--- a/mokakbob-api/build.gradle
+++ b/mokakbob-api/build.gradle
@@ -18,7 +18,7 @@ dependencies {
 
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-    implementation 'org.redisson:redisson-spring-boot-starter:3.50.0'
+    implementation 'org.redisson:redisson-spring-boot-starter:3.27.2'
 
     // jwt
     implementation("io.jsonwebtoken:jjwt-api:0.11.5")

--- a/mokakbob-api/build.gradle
+++ b/mokakbob-api/build.gradle
@@ -18,6 +18,7 @@ dependencies {
 
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.redisson:redisson-spring-boot-starter:3.50.0'
 
     // jwt
     implementation("io.jsonwebtoken:jjwt-api:0.11.5")

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/controller/MatchingController.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/controller/MatchingController.java
@@ -21,7 +21,7 @@ public class MatchingController {
             @RequestBody MatchingStartRequest request,
             @MemberId Long memberId
     ) {
-        startService.participateMatching(
+        startService.participateMatchingWithLock(
                 request.lat(),
                 request.lng(),
                 request.category(),

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/controller/MatchingController.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/controller/MatchingController.java
@@ -14,14 +14,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class MatchingController {
 
-    private final MatchingStartService startService;
+    private final MatchingStartService matchingStartService;
 
     @PostMapping(MatchingPath.PARTICIPATE)
     public ResponseEntity<Void> startMatching(
             @RequestBody MatchingStartRequest request,
             @MemberId Long memberId
     ) {
-        startService.participateMatchingWithLock(
+        matchingStartService.participateMatchingWithLock(
                 request.lat(),
                 request.lng(),
                 request.category(),

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/exception/MatchingErrorCode.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/exception/MatchingErrorCode.java
@@ -5,6 +5,7 @@ import com.mokakbob.common.exception.exceptions.ApiErrorCode;
 public enum MatchingErrorCode implements ApiErrorCode {
     EXIST_MATCHING(400, "M001", "이미 매칭에 참여 중입니다."),
     MATCHING_OPERATION_INTERRUPTED(500, "M002", "매칭 작업이 시스템에 의해 중단되었습니다."),
+    NOT_ENOUGH_MATCHING_POINT(400, "M003", "매칭에 참여할 포인트가 부족합니다.")
     ;
     private final int httpStatus;
     private final String customCode;

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/exception/MatchingErrorCode.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/exception/MatchingErrorCode.java
@@ -4,6 +4,7 @@ import com.mokakbob.common.exception.exceptions.ApiErrorCode;
 
 public enum MatchingErrorCode implements ApiErrorCode {
     EXIST_MATCHING(400, "M001", "이미 매칭에 참여 중입니다."),
+    MATCHING_OPERATION_INTERRUPTED(500, "M002", "매칭 작업이 시스템에 의해 중단되었습니다."),
     ;
     private final int httpStatus;
     private final String customCode;

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/service/MatchingStartService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/service/MatchingStartService.java
@@ -2,36 +2,23 @@ package com.mokakbob.matching.service;
 
 import com.mokakbob.common.exception.exceptions.ApiException;
 import com.mokakbob.domain.matching.domain.vo.MatchingCategory;
-import com.mokakbob.domain.matching.service.MatchingService;
-import com.mokakbob.domain.member.domain.Member;
-import com.mokakbob.domain.member.service.MemberService;
 import com.mokakbob.matching.exception.MatchingErrorCode;
-import com.mokakbob.matching.ParticipantRedisStore;
-import com.mokakbob.matching.service.event.MatchingParticipateEvent;
-import java.math.BigDecimal;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class MatchingStartService {
 
-    private static final int DEFAULT_DEDUCE_POINT = 2000;
     private static final int LIMIT_LOCK_CATCH_TIME = 3;
     private static final int LOCK_DURATION_TIME = 10;
 
-    private final ParticipantRedisStore participantStore;
-    private final MemberService memberService;
-    private final MatchingService matchingService;
-    private final ApplicationEventPublisher eventPublisher;
+    private final MatchingTransactionService matchingTransactionService;
     private final RedissonClient redissonClient;
 
-    @Transactional
     public void participateMatchingWithLock(double lat, double lng, MatchingCategory category, int participantCount,
                                             Long memberId) {
         String lockKey = "lock:member:" + memberId + ":participation";
@@ -39,7 +26,7 @@ public class MatchingStartService {
 
         try {
             if (lock.tryLock(LIMIT_LOCK_CATCH_TIME, LOCK_DURATION_TIME, TimeUnit.SECONDS)) {
-                participateMatching(lat, lng, category, participantCount, memberId);
+                matchingTransactionService.participateMatching(lat, lng, category, participantCount, memberId);
             } else {
                 throw new ApiException(MatchingErrorCode.EXIST_MATCHING);
             }
@@ -50,36 +37,6 @@ public class MatchingStartService {
             if (lock.isHeldByCurrentThread()) {
                 lock.unlock();
             }
-        }
-    }
-
-    private void participateMatching(double lat, double lng, MatchingCategory category, int participantCount,
-                                     Long memberId) {
-        validateExistParticipating(memberId);
-        deducePoint(memberId);
-
-        matchingService.saveMatchingRequest(memberId, category, participantCount, new BigDecimal(lat),
-                new BigDecimal(lng));
-
-        MatchingParticipateEvent event = new MatchingParticipateEvent(memberId, lat, lng, category, participantCount);
-
-        eventPublisher.publishEvent(event);
-    }
-
-
-    private void deducePoint(Long memberId) {
-        Member member = memberService.findMember(memberId);
-
-        if(member.getDepositPoint() < DEFAULT_DEDUCE_POINT) {
-            throw new ApiException(MatchingErrorCode.NOT_ENOUGH_MATCHING_POINT);
-        }
-
-        member.deductPoint(DEFAULT_DEDUCE_POINT);
-    }
-
-    private void validateExistParticipating(Long memberId) {
-        if (participantStore.isAlreadyParticipating(memberId)) {
-            throw new ApiException(MatchingErrorCode.EXIST_MATCHING);
         }
     }
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/service/MatchingStartService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/service/MatchingStartService.java
@@ -9,7 +9,10 @@ import com.mokakbob.matching.exception.MatchingErrorCode;
 import com.mokakbob.matching.ParticipantRedisStore;
 import com.mokakbob.matching.service.event.MatchingParticipateEvent;
 import java.math.BigDecimal;
+import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,15 +22,39 @@ import org.springframework.transaction.annotation.Transactional;
 public class MatchingStartService {
 
     private static final int DEFAULT_DEDUCE_POINT = 2000;
+    private static final int LIMIT_LOCK_CATCH_TIME = 3;
+    private static final int LOCK_DURATION_TIME = 10;
 
     private final ParticipantRedisStore participantStore;
     private final MemberService memberService;
     private final MatchingService matchingService;
     private final ApplicationEventPublisher eventPublisher;
+    private final RedissonClient redissonClient;
 
     @Transactional
-    public void participateMatching(double lat, double lng, MatchingCategory category, int participantCount,
-                                    Long memberId) {
+    public void participateMatchingWithLock(double lat, double lng, MatchingCategory category, int participantCount,
+                                            Long memberId) {
+        String lockKey = "lock:member:" + memberId + ":participation";
+        RLock lock = redissonClient.getLock(lockKey);
+
+        try {
+            if (lock.tryLock(LIMIT_LOCK_CATCH_TIME, LOCK_DURATION_TIME, TimeUnit.SECONDS)) {
+                participateMatching(lat, lng, category, participantCount, memberId);
+            } else {
+                throw new ApiException(MatchingErrorCode.EXIST_MATCHING);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new ApiException(MatchingErrorCode.MATCHING_OPERATION_INTERRUPTED);
+        } finally {
+            if (lock.isHeldByCurrentThread()) {
+                lock.unlock();
+            }
+        }
+    }
+
+    private void participateMatching(double lat, double lng, MatchingCategory category, int participantCount,
+                                     Long memberId) {
         validateExistParticipating(memberId);
         deducePoint(memberId);
 

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/service/MatchingStartService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/service/MatchingStartService.java
@@ -69,6 +69,11 @@ public class MatchingStartService {
 
     private void deducePoint(Long memberId) {
         Member member = memberService.findMember(memberId);
+
+        if(member.getDepositPoint() < DEFAULT_DEDUCE_POINT) {
+            throw new ApiException(MatchingErrorCode.NOT_ENOUGH_MATCHING_POINT);
+        }
+
         member.deductPoint(DEFAULT_DEDUCE_POINT);
     }
 

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/service/MatchingTransactionService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/service/MatchingTransactionService.java
@@ -41,7 +41,7 @@ public class MatchingTransactionService {
 
 
     private void deducePoint(Long memberId) {
-        Member member = memberService.findMember(memberId);
+        Member member = memberService.findMemberForUpdate(memberId);
 
         if(member.getDepositPoint() < DEFAULT_DEDUCE_POINT) {
             throw new ApiException(MatchingErrorCode.NOT_ENOUGH_MATCHING_POINT);

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/service/MatchingTransactionService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/service/MatchingTransactionService.java
@@ -1,0 +1,58 @@
+package com.mokakbob.matching.service;
+
+import com.mokakbob.common.exception.exceptions.ApiException;
+import com.mokakbob.domain.matching.domain.vo.MatchingCategory;
+import com.mokakbob.domain.matching.service.MatchingService;
+import com.mokakbob.domain.member.domain.Member;
+import com.mokakbob.domain.member.service.MemberService;
+import com.mokakbob.matching.exception.MatchingErrorCode;
+import com.mokakbob.matching.ParticipantRedisStore;
+import com.mokakbob.matching.service.event.MatchingParticipateEvent;
+import java.math.BigDecimal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MatchingTransactionService {
+
+    private static final int DEFAULT_DEDUCE_POINT = 2000;
+
+    private final ParticipantRedisStore participantStore;
+    private final MemberService memberService;
+    private final MatchingService matchingService;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Transactional
+    public void participateMatching(double lat, double lng, MatchingCategory category, int participantCount,
+                                     Long memberId) {
+        validateExistParticipating(memberId);
+        deducePoint(memberId);
+
+        matchingService.saveMatchingRequest(memberId, category, participantCount, new BigDecimal(lat),
+                new BigDecimal(lng));
+
+        MatchingParticipateEvent event = new MatchingParticipateEvent(memberId, lat, lng, category, participantCount);
+
+        eventPublisher.publishEvent(event);
+    }
+
+
+    private void deducePoint(Long memberId) {
+        Member member = memberService.findMember(memberId);
+
+        if(member.getDepositPoint() < DEFAULT_DEDUCE_POINT) {
+            throw new ApiException(MatchingErrorCode.NOT_ENOUGH_MATCHING_POINT);
+        }
+
+        member.deductPoint(DEFAULT_DEDUCE_POINT);
+    }
+
+    private void validateExistParticipating(Long memberId) {
+        if (participantStore.isAlreadyParticipating(memberId)) {
+            throw new ApiException(MatchingErrorCode.EXIST_MATCHING);
+        }
+    }
+}

--- a/mokakbob-api/src/test/java/com/mokakbob/matching/service/MatchingTransactionServiceTest.java
+++ b/mokakbob-api/src/test/java/com/mokakbob/matching/service/MatchingTransactionServiceTest.java
@@ -23,10 +23,10 @@ import org.springframework.kafka.core.KafkaTemplate;
 
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings("NonAsciiCharacters")
-class MatchingStartServiceTest {
+class MatchingTransactionServiceTest {
 
     @InjectMocks
-    private MatchingStartService matchingStartService;
+    private MatchingTransactionService matchingTransactionService;
 
     @Mock
     private ParticipantRedisStore participantStore;
@@ -62,7 +62,7 @@ class MatchingStartServiceTest {
         given(memberService.findMember(memberId)).willReturn(fakeMember);
 
         // when
-        matchingStartService.participateMatching(lat, lng, category, participantCount, memberId);
+        matchingTransactionService.participateMatching(lat, lng, category, participantCount, memberId);
 
         // then
         verify(participantStore).isAlreadyParticipating(memberId);

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/member/repository/MemberRepository.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/member/repository/MemberRepository.java
@@ -6,6 +6,7 @@ import jakarta.persistence.QueryHint;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.stereotype.Repository;
 
@@ -21,6 +22,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByNickname(String nickName);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select m from Member m where m.id = :id")
     @QueryHints(@QueryHint(name = "jakarta.persistence.lock.timeout", value = "5000"))
     Optional<Member> findByIdForUpdate(Long id);
 }

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/member/repository/MemberRepository.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/member/repository/MemberRepository.java
@@ -1,8 +1,12 @@
 package com.mokakbob.domain.member.repository;
 
 import com.mokakbob.domain.member.domain.Member;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -15,4 +19,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
 
     Optional<Member> findByNickname(String nickName);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints(@QueryHint(name = "jakarta.persistence.lock.timeout", value = "5000"))
+    Optional<Member> findByIdForUpdate(Long id);
 }

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/member/service/MemberService.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/member/service/MemberService.java
@@ -54,6 +54,12 @@ public class MemberService {
                 .orElseThrow(()-> new DomainException(MemberErrorCode.NOT_FOUND_MEMBER));
     }
 
+    @Transactional
+    public Member findMemberForUpdate(Long memberId) {
+        return memberRepository.findByIdForUpdate(memberId)
+                .orElseThrow(() -> new DomainException(MemberErrorCode.NOT_FOUND_MEMBER));
+    }
+
     private void validateDuplicateEmail(String email) {
         if (memberRepository.existsByEmail(email)) {
             throw new DomainException(MemberErrorCode.DUPLICATE_EMAIL);

--- a/mokakbob-redis/build.gradle
+++ b/mokakbob-redis/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.redisson:redisson-spring-boot-starter:3.50.0'
 
     implementation project(':mokakbob-core')
 }

--- a/mokakbob-redis/build.gradle
+++ b/mokakbob-redis/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-    implementation 'org.redisson:redisson-spring-boot-starter:3.50.0'
+    implementation 'org.redisson:redisson-spring-boot-starter:3.27.2'
 
     implementation project(':mokakbob-core')
 }

--- a/mokakbob-redis/src/main/java/com/mokakbob/config/RedissonConfig.java
+++ b/mokakbob-redis/src/main/java/com/mokakbob/config/RedissonConfig.java
@@ -1,0 +1,21 @@
+package com.mokakbob.config;
+
+
+import java.io.IOException;
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.Resource;
+
+@Configuration
+public class RedissonConfig {
+
+    @Bean(destroyMethod = "shutdown")
+    public RedissonClient redissonClient(@Value("classpath:redisson.yml") Resource configFile) throws IOException {
+        Config config = Config.fromYAML(configFile.getInputStream());
+        return Redisson.create(config);
+    }
+}

--- a/mokakbob-redis/src/main/resources/redisson.yml
+++ b/mokakbob-redis/src/main/resources/redisson.yml
@@ -1,0 +1,6 @@
+sentinelServersConfig:
+  masterName: "mymaster"
+  sentinelAddresses:
+    - "redis://127.0.0.1:26379"
+    - "redis://127.0.0.1:26380"
+    - "redis://127.0.0.1:26381"


### PR DESCRIPTION
## 관련 이슈 번호
#47 closed

## 작업 내용 25.08.19
* 매칭 참가 기능 동시성 문제 해결 로직 적용

### `Redisson` 분산락 적용
* `Redisson`의 `RLock`을 이용해 동일한 매칭 요청에 대해 동시에 두 명 이상이 참가 처리되는 문제 방지하였습니다.
* `memberId`를 기준으로 락 키를 설정하였습니다.
* `tryLock(waitTime, leaseTime) `방식을 적용하여, 락 대기 시간과 점유 시간을 설정했습니다.
* 락 해제는 `finally` 를 통해 보장하여 데드락을 방지했습니다.

### 트랜잭션 범위 설정
~~~
@Transaction
public void participateMatchingWithLock(~~)
~~~
* 기존에는 위와 같은 형식으로 코드를 작성하였습니다.
* 락을 획득하는 단계에서 `@Transaction` 어노테이션을 적용하였고, 이로 인해 락 해제 시점과 DB 트랜잭션 타이밍이 꼬일 수 있다는 생각이 들었습니다.


~~~
public void participateMatchingWithLock(~~) {
    
    
    try {
            if (lock.tryLock(LIMIT_LOCK_CATCH_TIME, LOCK_DURATION_TIME, TimeUnit.SECONDS)) {
                matchingTransactionService.participateMatching(lat, lng, category, participantCount, memberId);
            } else {
                throw new ApiException(MatchingErrorCode.EXIST_MATCHING);
            }
        }
        
}

@Transactional
public void participateMatching()
~~~                                    
* 따라서, 위와 같이 락을 획득하는 단계와 트랜잭션 연산이 필요한 단계를 분리하였습니다.      
* `락 획득 → 트랜잭션 시작 → 비즈니스 로직 실행 → 트랜잭션 종료 → finally에서 락 해제` 순서를 보장하였습니다.

### Pessimistic Lock 적용
* **Perssimistic Lock 적용 이유**
  * `Redisson`을 사용하여 분산락은 걸었지만, DB 내부에서의 레이스 컨디션은 여전히 발생할 수 있음을 인지하였습니다.(락이 해제된 경우)
  * 또한 매칭 요청 API 의 경우, 수많은 요청이 예상되고 내부에 `deducePoint` (포인트 감소) 로직이 존재합니다. 
  * 해당 로직에 낙관적 락을 적용시킬 경우, 충돌이 계속 발생하여 스레드 지연과 같은 문제가 발생할 수 있다고 판단하여 비관적 락 적용하였습니다.

~~~
@Lock(LockModeType.PESSIMISTIC_WRITE)
@Query("select m from Member m where m.id = :id")
@QueryHints(@QueryHint(name = "jakarta.persistence.lock.timeout", value = "5000"))
Optional<Member> findByIdForUpdate(Long id);
~~~
* 위와 같은 방식으로 비관적 락 적용하였습니다.
* Jpa 의 메서드 이름 파싱을 방지하기 위해 `@Query` 어노테이션으로 쿼리 명시하였습니다.
* 또한, 데드락을 방지하기 위해 `@QueryHints`를 사용하여 락 경합 시 최대 5초만 대기하도록 하였습니다.