### PR TITLE
#51 [FEAT] 매칭 기능 Consumer 로직 뼈대 구현 

### DIFF
--- a/mokakbob-api/src/main/java/com/mokakbob/admin/service/AdminKafkaService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/admin/service/AdminKafkaService.java
@@ -21,7 +21,7 @@ public class AdminKafkaService {
         );
 
         try {
-            kafkaTemplate.send(KafkaTopic.MATCHING_PARTICIPATE.getTopicName(), key, event);
+            kafkaTemplate.send(KafkaTopic.MATCHING_PARTICIPATE, key, event);
         } catch (Exception e) {
             log.error("카프카 토픽 재발급 실패: {}\n실패한 이벤트: {}\n재처리 필요 정보 - memberId: {}, key: {}, lat: {}, lng: {}, category: {}, participantCount: {}",
                     e.getMessage(),

--- a/mokakbob-api/src/main/java/com/mokakbob/admin/service/AdminKafkaService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/admin/service/AdminKafkaService.java
@@ -1,7 +1,7 @@
 package com.mokakbob.admin.service;
 
 import com.mokakbob.domain.matching.domain.vo.MatchingCategory;
-import com.mokakbob.matching.service.event.MatchingParticipateEvent;
+import com.mokakbob.domain.matching.event.MatchingParticipateEvent;
 import com.mokakbob.topic.KafkaTopic;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/mokakbob-api/src/main/java/com/mokakbob/common/exception/handler/ConsumerExceptionHandler.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/common/exception/handler/ConsumerExceptionHandler.java
@@ -1,0 +1,25 @@
+package com.mokakbob.common.exception.handler;
+
+import com.mokakbob.common.exception.handler.response.CustomErrorResponse;
+import com.mokakbob.matching.common.exception.exceptions.ConsumerErrorCode;
+import com.mokakbob.matching.common.exception.exceptions.ConsumerException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ConsumerExceptionHandler {
+
+    @ExceptionHandler(ConsumerException.class)
+    public ResponseEntity<CustomErrorResponse> handleException(ConsumerException e) {
+        ConsumerErrorCode baseErrorCode = e.apiErrorCode();
+
+        CustomErrorResponse response = new CustomErrorResponse(
+                baseErrorCode.customCode(),
+                baseErrorCode.message()
+        );
+
+        return ResponseEntity.status(baseErrorCode.httpStatus())
+                .body(response);
+    }
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/config/KafkaProducerConfig.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/config/KafkaProducerConfig.java
@@ -21,7 +21,7 @@ public class KafkaProducerConfig {
 
     private final KafkaProducerLoggingListener loggingListener;
 
-    @Value("${spring.kafka.bootstrap-servers}")
+    @Value("${spring.kafka.bootstrap-servers:localhost:9092}")
     private String bootstrapServers;
 
     @Bean

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/listener/MatchingParticipateEventListener.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/listener/MatchingParticipateEventListener.java
@@ -2,7 +2,7 @@ package com.mokakbob.matching.listener;
 
 import com.mokakbob.matching.service.MatchingWriterService;
 import com.mokakbob.topic.KafkaTopic;
-import com.mokakbob.matching.service.event.MatchingParticipateEvent;
+import com.mokakbob.domain.matching.event.MatchingParticipateEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.core.KafkaTemplate;

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/listener/MatchingParticipateEventListener.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/listener/MatchingParticipateEventListener.java
@@ -31,7 +31,7 @@ public class MatchingParticipateEventListener {
         String idempotencyKey = generateIdempotencyKey(String.valueOf(event.memberId()));
 
         try {
-            kafkaTemplate.send(KafkaTopic.MATCHING_PARTICIPATE.getTopicName(), idempotencyKey, event);
+            kafkaTemplate.send(KafkaTopic.MATCHING_PARTICIPATE, idempotencyKey, event);
         } catch (Exception e) {
             log.error("카프카 토픽 발급 실패: {}\n실패한 이벤트: {}\n재처리 필요 정보 - memberId: {}, key: {}, lat: {}, lng: {}, category: {}, participantCount: {}",
                     e.getMessage(),

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/service/MatchingTransactionService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/service/MatchingTransactionService.java
@@ -7,7 +7,7 @@ import com.mokakbob.domain.member.domain.Member;
 import com.mokakbob.domain.member.service.MemberService;
 import com.mokakbob.matching.exception.MatchingErrorCode;
 import com.mokakbob.matching.ParticipantRedisStore;
-import com.mokakbob.matching.service.event.MatchingParticipateEvent;
+import com.mokakbob.domain.matching.event.MatchingParticipateEvent;
 import java.math.BigDecimal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;

--- a/mokakbob-api/src/main/java/com/mokakbob/matching/service/MatchingWriterService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/service/MatchingWriterService.java
@@ -4,7 +4,7 @@ import com.mokakbob.cache.CategoryQueueStore;
 import com.mokakbob.cache.ParticipantGeoStore;
 import com.mokakbob.cache.ParticipantStore;
 import com.mokakbob.matching.annotation.RedisRetryable;
-import com.mokakbob.matching.service.event.MatchingParticipateEvent;
+import com.mokakbob.domain.matching.event.MatchingParticipateEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 

--- a/mokakbob-api/src/main/resources/application.yml
+++ b/mokakbob-api/src/main/resources/application.yml
@@ -3,6 +3,8 @@ spring:
     active: local
 
   kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP:localhost:9092}
+
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer

--- a/mokakbob-api/src/test/java/com/mokakbob/matching/service/MatchingTransactionServiceTest.java
+++ b/mokakbob-api/src/test/java/com/mokakbob/matching/service/MatchingTransactionServiceTest.java
@@ -71,6 +71,6 @@ class MatchingTransactionServiceTest {
         verify(geoStore).addMemberLocation(memberId, lng, lat);
         verify(participantStore).transitionToParticipating(memberId);
         verify(categoryQueueStore).addToQueue(category, participantCount, memberId);
-        verify(kafkaTemplate).send(eq(KafkaTopic.MATCHING_PARTICIPATE.getTopicName()), any(MatchingParticipateEvent.class));
+        verify(kafkaTemplate).send(eq(KafkaTopic.MATCHING_PARTICIPATE), any(MatchingParticipateEvent.class));
     }
 }

--- a/mokakbob-api/src/test/java/com/mokakbob/matching/service/MatchingTransactionServiceTest.java
+++ b/mokakbob-api/src/test/java/com/mokakbob/matching/service/MatchingTransactionServiceTest.java
@@ -13,7 +13,7 @@ import com.mokakbob.domain.member.service.MemberService;
 import com.mokakbob.cache.CategoryQueueStore;
 import com.mokakbob.cache.ParticipantGeoStore;
 import com.mokakbob.matching.ParticipantRedisStore;
-import com.mokakbob.matching.service.event.MatchingParticipateEvent;
+import com.mokakbob.domain.matching.event.MatchingParticipateEvent;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;

--- a/mokakbob-consumer/build.gradle
+++ b/mokakbob-consumer/build.gradle
@@ -1,3 +1,5 @@
 dependencies {
+    implementation project(':mokakbob-core')
+
     implementation 'org.springframework.kafka:spring-kafka'
 }

--- a/mokakbob-consumer/src/main/java/com/mokakbob/matching/common/exception/exceptions/ConsumerErrorCode.java
+++ b/mokakbob-consumer/src/main/java/com/mokakbob/matching/common/exception/exceptions/ConsumerErrorCode.java
@@ -1,0 +1,10 @@
+package com.mokakbob.matching.common.exception.exceptions;
+
+public interface ConsumerErrorCode {
+
+    int httpStatus();
+
+    String customCode();
+
+    String message();
+}

--- a/mokakbob-consumer/src/main/java/com/mokakbob/matching/common/exception/exceptions/ConsumerException.java
+++ b/mokakbob-consumer/src/main/java/com/mokakbob/matching/common/exception/exceptions/ConsumerException.java
@@ -1,0 +1,15 @@
+package com.mokakbob.matching.common.exception.exceptions;
+
+public class ConsumerException extends RuntimeException {
+
+    private final ConsumerErrorCode errorCode;
+
+    public ConsumerException(ConsumerErrorCode errorCode) {
+        super(errorCode.customCode() + ": " + errorCode.message());
+        this.errorCode = errorCode;
+    }
+
+    public ConsumerErrorCode apiErrorCode() {
+        return errorCode;
+    }
+}

--- a/mokakbob-consumer/src/main/java/com/mokakbob/matching/config/KafkaConsumerConfig.java
+++ b/mokakbob-consumer/src/main/java/com/mokakbob/matching/config/KafkaConsumerConfig.java
@@ -1,0 +1,43 @@
+package com.mokakbob.matching.config;
+
+import com.mokakbob.domain.matching.event.MatchingParticipateEvent;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+@Configuration
+@RequiredArgsConstructor
+public class KafkaConsumerConfig {
+
+    @Value("${spring.kafka.bootstrap-servers:localhost:9092}")
+    private String bootstrapServers;
+
+    @Bean
+    public ConsumerFactory<String, MatchingParticipateEvent> matchingParticipateConsumerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "matching-participate-consumers");
+        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        props.put(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG,
+                "org.apache.kafka.clients.consumer.CooperativeStickyAssignor");
+
+        JsonDeserializer<MatchingParticipateEvent> json = new JsonDeserializer<>(MatchingParticipateEvent.class, false);
+        json.addTrustedPackages("com.mokakbob.**");
+
+        return new DefaultKafkaConsumerFactory<>(
+                props,
+                new StringDeserializer(),
+                new ErrorHandlingDeserializer<>(json)
+        );
+    }
+}

--- a/mokakbob-consumer/src/main/java/com/mokakbob/matching/config/KafkaListenerContainerConfig.java
+++ b/mokakbob-consumer/src/main/java/com/mokakbob/matching/config/KafkaListenerContainerConfig.java
@@ -21,7 +21,7 @@ public class KafkaListenerContainerConfig {
 
         var factory = new ConcurrentKafkaListenerContainerFactory<String, MatchingParticipateEvent>();
         factory.setConsumerFactory(matchingParticipateConsumerFactory);
-        factory.setConcurrency(3);
+        factory.setConcurrency(1);
         factory.getContainerProperties().setAckMode(
                 org.springframework.kafka.listener.ContainerProperties.AckMode.MANUAL_IMMEDIATE
         );

--- a/mokakbob-consumer/src/main/java/com/mokakbob/matching/config/KafkaListenerContainerConfig.java
+++ b/mokakbob-consumer/src/main/java/com/mokakbob/matching/config/KafkaListenerContainerConfig.java
@@ -1,0 +1,31 @@
+package com.mokakbob.matching.config;
+
+import com.mokakbob.domain.matching.event.MatchingParticipateEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+
+@EnableKafka
+@Configuration
+@RequiredArgsConstructor
+public class KafkaListenerContainerConfig {
+
+    private final ConsumerFactory<String, MatchingParticipateEvent> matchingParticipateConsumerFactory;
+
+    @Bean(name = "matchingParticipateKafkaListenerContainerFactory")
+    public ConcurrentKafkaListenerContainerFactory<String, MatchingParticipateEvent>
+    matchingParticipateKafkaListenerContainerFactory() {
+
+        var factory = new ConcurrentKafkaListenerContainerFactory<String, MatchingParticipateEvent>();
+        factory.setConsumerFactory(matchingParticipateConsumerFactory);
+        factory.setConcurrency(3);
+        factory.getContainerProperties().setAckMode(
+                org.springframework.kafka.listener.ContainerProperties.AckMode.MANUAL_IMMEDIATE
+        );
+
+        return factory;
+    }
+}

--- a/mokakbob-consumer/src/main/java/com/mokakbob/matching/consumer/MatchingParticipateConsumer.java
+++ b/mokakbob-consumer/src/main/java/com/mokakbob/matching/consumer/MatchingParticipateConsumer.java
@@ -2,6 +2,7 @@ package com.mokakbob.matching.consumer;
 
 import com.mokakbob.domain.matching.event.MatchingParticipateEvent;
 import com.mokakbob.matching.service.MatchingParticipateService;
+import com.mokakbob.topic.KafkaTopic;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -17,7 +18,7 @@ public class MatchingParticipateConsumer {
     private final MatchingParticipateService participateService;
 
     @KafkaListener(
-            topics = "${app.topic.matching-participate:matching.participate}",
+            topics = KafkaTopic.MATCHING_PARTICIPATE,
             containerFactory = "matchingParticipateKafkaListenerContainerFactory"
     )
     public void onMessage(ConsumerRecord<String, MatchingParticipateEvent> record, Acknowledgment ack) {

--- a/mokakbob-consumer/src/main/java/com/mokakbob/matching/consumer/MatchingParticipateConsumer.java
+++ b/mokakbob-consumer/src/main/java/com/mokakbob/matching/consumer/MatchingParticipateConsumer.java
@@ -1,0 +1,36 @@
+package com.mokakbob.matching.consumer;
+
+import com.mokakbob.domain.matching.event.MatchingParticipateEvent;
+import com.mokakbob.matching.service.MatchingParticipateService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MatchingParticipateConsumer {
+
+    private final MatchingParticipateService participateService;
+
+    @KafkaListener(
+            topics = "${app.topic.matching-participate:matching.participate}",
+            containerFactory = "matchingParticipateKafkaListenerContainerFactory"
+    )
+    public void onMessage(ConsumerRecord<String, MatchingParticipateEvent> record, Acknowledgment ack) {
+        final String key = record.key();
+        final MatchingParticipateEvent event = record.value();
+
+        try {
+            participateService.participateMatching(event);
+            ack.acknowledge();
+            log.info("[OK] key={}, partition={}, offset={}", key, record.partition(), record.offset());
+        } catch (Exception e) {
+            log.error("[ERR] key={}, partition={}, offset={}, cause={}", key, record.partition(), record.offset(), e.toString());
+            throw e;
+        }
+    }
+}

--- a/mokakbob-consumer/src/main/java/com/mokakbob/matching/service/MatchingParticipateService.java
+++ b/mokakbob-consumer/src/main/java/com/mokakbob/matching/service/MatchingParticipateService.java
@@ -1,0 +1,12 @@
+package com.mokakbob.matching.service;
+
+import com.mokakbob.domain.matching.event.MatchingParticipateEvent;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MatchingParticipateService {
+
+    public void participateMatching(MatchingParticipateEvent event) {
+        // to do
+    }
+}

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/matching/event/MatchingParticipateEvent.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/matching/event/MatchingParticipateEvent.java
@@ -1,4 +1,4 @@
-package com.mokakbob.matching.service.event;
+package com.mokakbob.domain.matching.event;
 
 import com.mokakbob.domain.matching.domain.vo.MatchingCategory;
 

--- a/mokakbob-core/src/main/java/com/mokakbob/topic/KafkaTopic.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/topic/KafkaTopic.java
@@ -1,19 +1,12 @@
 package com.mokakbob.topic;
 
-import lombok.Getter;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
-@Getter
-public enum KafkaTopic {
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class KafkaTopic {
 
-    // 매칭 참여 토픽
-    MATCHING_PARTICIPATE("matching.participate"),
-    MATCHING_FOUND("matching.found"),
-    MATCHING_SUCCESS("matching.success")
-    ;
-
-    private final String topicName;
-
-    KafkaTopic(String topicName) {
-        this.topicName = topicName;
-    }
+    public static final String MATCHING_PARTICIPATE = "matching.participate";
+    public static final String MATCHING_FOUND       = "matching.found";
+    public static final String MATCHING_SUCCESS     = "matching.success";
 }


### PR DESCRIPTION
## 관련 이슈 번호
#51 closed

## 작업 내용 25.08.23

### Kafka Consumer 설정
* 확실한 토픽의 소비와 재처리 제어를 위해 자동 커밋을 끄고(enable.auto.commit=false), 수동 ACK(MANUAL_IMMEDIATE)로 커밋 시점을 로직이 성공되는 시점으로 설정하였습니다.
* 또한, JSON 역직렬화 실패 시 컨테이너가 죽지 않도록 ErrorHandlingDeserializer를 사용합니다.
* `CooperativeStickyAssignor` 설정을 통해 점진적으로 파티션을 갈아치우는 방식을 선택하였습니다.(서비스 멈춤 현상 최소화 하기 위해)
* `concurrency = 1`
  * 현재 파티션 개수가 1개라 Concurrency 도 1로 설정하였습니다.
  * 추후 부하 테스트 결과에 따라 파티션 개수와 Concurrency 값 수정해보면 좋을 것 같습니다!
  
### 추후 구현 사항
*  메시지 Consume 재처리를 위한 dlq  로직 / 멱등성 보장을 위한 로직 