### PR TITLE
#53 [FEAT] 매칭 시, 거리기반(GEO) 저장소 키 값에 카테고리를 포함하여 필터링 가능하도록 구현

### DIFF
--- a/mokakbob-api/src/main/java/com/mokakbob/matching/service/MatchingWriterService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/service/MatchingWriterService.java
@@ -23,7 +23,7 @@ public class MatchingWriterService {
 
     @RedisRetryable
     public void saveGeo(MatchingParticipateEvent event) {
-        geoStore.addMemberLocation(event.memberId(), event.lng(), event.lat());
+        geoStore.addMemberLocation(event.category(), event.participantCount(), event.memberId(), event.lng(), event.lat());
     }
 
     @RedisRetryable

--- a/mokakbob-api/src/test/java/com/mokakbob/matching/service/MatchingTransactionServiceTest.java
+++ b/mokakbob-api/src/test/java/com/mokakbob/matching/service/MatchingTransactionServiceTest.java
@@ -68,7 +68,7 @@ class MatchingTransactionServiceTest {
         verify(participantStore).isAlreadyParticipating(memberId);
         verify(memberService).findMember(memberId);
         verify(matchingService).saveMatchingRequest(eq(memberId), eq(category), eq(participantCount), any(), any());
-        verify(geoStore).addMemberLocation(memberId, lng, lat);
+        verify(geoStore).addMemberLocation(category, participantCount, memberId, lng, lat);
         verify(participantStore).transitionToParticipating(memberId);
         verify(categoryQueueStore).addToQueue(category, participantCount, memberId);
         verify(kafkaTemplate).send(eq(KafkaTopic.MATCHING_PARTICIPATE), any(MatchingParticipateEvent.class));

--- a/mokakbob-consumer/src/main/java/com/mokakbob/matching/exception/MatchingConsumerErrorCode.java
+++ b/mokakbob-consumer/src/main/java/com/mokakbob/matching/exception/MatchingConsumerErrorCode.java
@@ -1,0 +1,33 @@
+package com.mokakbob.matching.exception;
+
+import com.mokakbob.matching.common.exception.exceptions.ConsumerErrorCode;
+
+public enum MatchingConsumerErrorCode implements ConsumerErrorCode {
+
+    ALREADY_PARTICIPATE_MATCHING(400, "C001", "이미 매칭 참여중입니다.")
+    ;
+    private final int httpStatus;
+    private final String customCode;
+    private final String message;
+
+    MatchingConsumerErrorCode(int httpStatus, String customCode, String message) {
+        this.httpStatus = httpStatus;
+        this.customCode = customCode;
+        this.message = message;
+    }
+
+    @Override
+    public int httpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String customCode() {
+        return customCode;
+    }
+
+    @Override
+    public String message() {
+        return message;
+    }
+}

--- a/mokakbob-consumer/src/main/java/com/mokakbob/matching/service/MatchingParticipateService.java
+++ b/mokakbob-consumer/src/main/java/com/mokakbob/matching/service/MatchingParticipateService.java
@@ -1,12 +1,25 @@
 package com.mokakbob.matching.service;
 
+import com.mokakbob.cache.CategoryQueueStore;
+import com.mokakbob.cache.ParticipantGeoStore;
+import com.mokakbob.cache.ParticipantStore;
 import com.mokakbob.domain.matching.event.MatchingParticipateEvent;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class MatchingParticipateService {
 
+    private final ParticipantStore participantStore;
+    private final ParticipantGeoStore geoStore;
+    private final CategoryQueueStore queueStore;
+
     public void participateMatching(MatchingParticipateEvent event) {
-        // to do
+        Long memberId = event.memberId();
+
+        if (!queueStore.hasEnoughForMatching(event.category(), event.participantCount())) {
+            return;
+        }
     }
 }

--- a/mokakbob-consumer/src/main/java/com/mokakbob/matching/service/MatchingParticipateService.java
+++ b/mokakbob-consumer/src/main/java/com/mokakbob/matching/service/MatchingParticipateService.java
@@ -1,8 +1,5 @@
 package com.mokakbob.matching.service;
 
-import com.mokakbob.cache.CategoryQueueStore;
-import com.mokakbob.cache.ParticipantGeoStore;
-import com.mokakbob.cache.ParticipantStore;
 import com.mokakbob.domain.matching.event.MatchingParticipateEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -11,15 +8,6 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class MatchingParticipateService {
 
-    private final ParticipantStore participantStore;
-    private final ParticipantGeoStore geoStore;
-    private final CategoryQueueStore queueStore;
-
     public void participateMatching(MatchingParticipateEvent event) {
-        Long memberId = event.memberId();
-
-        if (!queueStore.hasEnoughForMatching(event.category(), event.participantCount())) {
-            return;
-        }
     }
 }

--- a/mokakbob-core/src/main/java/com/mokakbob/cache/CategoryQueueStore.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/cache/CategoryQueueStore.java
@@ -1,10 +1,9 @@
 package com.mokakbob.cache;
 
 import com.mokakbob.domain.matching.domain.vo.MatchingCategory;
-import java.util.List;
 
 public interface CategoryQueueStore {
     void addToQueue(MatchingCategory category, int count, Long memberId);
     void removeFromQueue(MatchingCategory category, int count, Long memberId);
-    List<Long> findWaitingUsers(MatchingCategory category, int count);
+    boolean hasEnoughForMatching(MatchingCategory category, int participantCount);
 }

--- a/mokakbob-core/src/main/java/com/mokakbob/cache/ParticipantGeoStore.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/cache/ParticipantGeoStore.java
@@ -1,10 +1,13 @@
 package com.mokakbob.cache;
 
+import com.mokakbob.domain.matching.domain.vo.MatchingCategory;
 import java.util.List;
+import java.util.Optional;
 
 public interface ParticipantGeoStore {
 
-    void addMemberLocation(Long memberId, double lng, double lat);
-    List<Long> findNearbyMembers(double lng, double lat, double radiusInMeters);
-    void removeMemberLocation(Long memberId);
+    void addMemberLocation(MatchingCategory category, int count, Long memberId, double lng, double lat);
+    List<Long> findNearbyMembers(MatchingCategory category, int count, double lng, double lat, double radiusInMeters);
+    void removeMemberLocation(MatchingCategory category, int count, Long memberId);
+    Optional<double[]> getLocation(MatchingCategory category, int count, Long memberId);
 }

--- a/mokakbob-redis/src/main/java/com/mokakbob/matching/CategoryQueueRedisStore.java
+++ b/mokakbob-redis/src/main/java/com/mokakbob/matching/CategoryQueueRedisStore.java
@@ -2,10 +2,6 @@ package com.mokakbob.matching;
 
 import com.mokakbob.domain.matching.domain.vo.MatchingCategory;
 import com.mokakbob.cache.CategoryQueueStore;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
@@ -37,20 +33,11 @@ public class CategoryQueueRedisStore implements CategoryQueueStore {
     }
 
     @Override
-    public List<Long> findWaitingUsers(MatchingCategory category, int count) {
-        String zsetKey = zsetKey(category, count);
+    public boolean hasEnoughForMatching(MatchingCategory category, int participantCount) {
+        Long existMembers = basicRedisTemplate.opsForZSet()
+                .zCard(zsetKey(category, participantCount));
 
-        Set<String> members = basicRedisTemplate.opsForZSet()
-                .range(zsetKey, 0, count - 1);
-
-        if (members == null || members.isEmpty()) {
-            return Collections.emptyList();
-        }
-
-        return members.stream()
-                .map(this::extractMemberId)
-                .flatMap(Optional::stream)
-                .toList();
+        return existMembers != null && existMembers >= participantCount;
     }
 
     private String zsetKey(MatchingCategory category, int participantCount) {
@@ -59,17 +46,5 @@ public class CategoryQueueRedisStore implements CategoryQueueStore {
 
     private String memberKey(Long memberId) {
         return MEMBER_KEY + memberId;
-    }
-
-    private Optional<Long> extractMemberId(String value) {
-        if (value != null && value.startsWith(MEMBER_KEY)) {
-            try {
-                return Optional.of(Long.parseLong(value.substring(7)));
-            } catch (NumberFormatException e) {
-                return Optional.empty();
-            }
-        }
-
-        return Optional.empty();
     }
 }

--- a/mokakbob-redis/src/main/java/com/mokakbob/matching/ParticipantGeoRedisStore.java
+++ b/mokakbob-redis/src/main/java/com/mokakbob/matching/ParticipantGeoRedisStore.java
@@ -1,6 +1,7 @@
 package com.mokakbob.matching;
 
 import com.mokakbob.cache.ParticipantGeoStore;
+import com.mokakbob.domain.matching.domain.vo.MatchingCategory;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -18,41 +19,61 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class ParticipantGeoRedisStore implements ParticipantGeoStore {
 
-    private static final String GEO_KEY = "matching:geo";
+    private static final String GEO_KEY = "matching:geo:%s:%d";
     private static final String MEMBER_KEY = "member:";
 
     private final RedisTemplate<String, String> basicRedisTemplate;
 
     @Override
-    public void addMemberLocation(Long memberId, double lng, double lat) {
-        String member = memberKey(memberId);
-
+    public void addMemberLocation(MatchingCategory category, int count, Long memberId, double lng, double lat) {
         basicRedisTemplate.opsForGeo()
-                .add(GEO_KEY, new Point(lng, lat), member);
+                .add(
+                        geoKey(category, count),
+                        new Point(lng, lat),
+                        memberKey(memberId)
+                );
     }
 
     @Override
-    public List<Long> findNearbyMembers(double lng, double lat, double radiusInMeters) {
+    public List<Long> findNearbyMembers(MatchingCategory category, int count, double lng, double lat, double radiusInMeters) {
         GeoResults<GeoLocation<String>> results = basicRedisTemplate.opsForGeo()
                 .radius(
-                        GEO_KEY,
+                        geoKey(category, count),
                         new Circle(new Point(lng, lat), new Distance(radiusInMeters, Metrics.METERS))
                 );
 
-        if (results == null) {
+        if (results == null || results.getContent().isEmpty()) {
             return Collections.emptyList();
         }
 
         return results.getContent().stream()
-                .map(result -> extractUserId(result.getContent().getName()))
+                .map(r -> extractUserId(r.getContent().getName()))
                 .flatMap(Optional::stream)
                 .toList();
     }
 
     @Override
-    public void removeMemberLocation(Long memberId) {
+    public void removeMemberLocation(MatchingCategory category, int count, Long memberId) {
         basicRedisTemplate.opsForGeo()
-                .remove(GEO_KEY, memberKey(memberId));
+                .remove(geoKey(category, count), memberKey(memberId));
+    }
+
+    @Override
+    public Optional<double[]> getLocation(MatchingCategory category, int count, Long memberId) {
+        List<Point> points = basicRedisTemplate.opsForGeo()
+                .position(geoKey(category, count), memberKey(memberId));
+
+        if (points == null || points.isEmpty() || points.get(0) == null) {
+            return Optional.empty();
+        }
+
+        Point p = points.get(0);
+
+        return Optional.of(new double[]{p.getY(), p.getX()});
+    }
+
+    private String geoKey(MatchingCategory category, int count) {
+        return GEO_KEY.formatted(category.name(), count);
     }
 
     private String memberKey(Long memberId) {
@@ -62,7 +83,7 @@ public class ParticipantGeoRedisStore implements ParticipantGeoStore {
     private Optional<Long> extractUserId(String value) {
         if (value != null && value.startsWith(MEMBER_KEY)) {
             try {
-                return Optional.of(Long.parseLong(value.substring(5)));
+                return Optional.of(Long.parseLong(value.substring(MEMBER_KEY.length())));
             } catch (NumberFormatException e) {
                 return Optional.empty();
             }


### PR DESCRIPTION
## 관련 이슈 번호
#53 closed

## 작업 내용 25.08.25

### Redis GEO 저장소 키 값 수정
* GEO 저장소의 키 값을 [카테고리 + 인원수] 로 두고, 위치도 함께 저장하여 한 번에 위치 필터링 가능하게 하였습니다. 



* 이렇게 구현한 이유는 다음과 같습니다.
  * 원래 구조는 [참여자 위치 저장소] + [카테고리 + 인원수 저장소] 로 이루어져있었습니다.
  * 위 방식처럼 두고 참여 로직을 구현하려 하니,  [카테고리 + 인원수 저장소] 에서 필터링 후, [참여자 위치 저장소] 에 모든 사용자 정보를 넣어줘야하는 과정이 생겼습니다.
  * 너무 불필요하게 자바 단 코드가 복잡해졌고, GEO 저장소의 키 값을 [카테고리 + 인원수] 로 두어 간결하게 구현하고자 해당 방식처럼 수정하였습니다.