### PR TITLE
#61 [FEAT] 매칭 확정을 위한 Consumer 알림 생성 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,8 +52,8 @@ subprojects {
 		useJUnitPlatform()
 	}
 
-	// core(도메인) 모듈 + kafka 모듈 + redis 모듈 bootJar 비활성화
-	if (project.name in ["mokakbob-core", "mokakbob-kafka", "mokakbob-redis"]) {
+	// core(도메인) 모듈 + kafka 모듈 + redis 모듈 + consumer 모듈 bootJar 비활성화
+	if (project.name in ["mokakbob-core", "mokakbob-kafka", "mokakbob-redis", "mokakbob-consumer"]) {
 		bootJar { enabled = false }
 		jar { enabled = true }
 	}

--- a/mokakbob-api/src/test/java/com/mokakbob/matching/service/MatchingTransactionServiceTest.java
+++ b/mokakbob-api/src/test/java/com/mokakbob/matching/service/MatchingTransactionServiceTest.java
@@ -5,22 +5,18 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
-import com.mokakbob.domain.matching.domain.vo.Location;
-import com.mokakbob.topic.KafkaTopic;
 import com.mokakbob.domain.matching.domain.vo.MatchingCategory;
 import com.mokakbob.domain.matching.service.MatchingService;
 import com.mokakbob.domain.member.domain.Member;
 import com.mokakbob.domain.member.service.MemberService;
-import com.mokakbob.cache.ParticipantGeoStore;
 import com.mokakbob.matching.ParticipantRedisStore;
 import com.mokakbob.domain.matching.event.MatchingParticipateEvent;
-import java.math.BigDecimal;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.context.ApplicationEventPublisher;
 
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings("NonAsciiCharacters")
@@ -33,16 +29,13 @@ class MatchingTransactionServiceTest {
     private ParticipantRedisStore participantStore;
 
     @Mock
-    private ParticipantGeoStore geoStore;
-
-    @Mock
     private MemberService memberService;
 
     @Mock
     private MatchingService matchingService;
 
     @Mock
-    private KafkaTemplate<String, Object> kafkaTemplate;
+    private ApplicationEventPublisher eventPublisher;
 
     @Test
     void 매칭_참여_정상_흐름_테스트() {
@@ -50,7 +43,6 @@ class MatchingTransactionServiceTest {
         Long memberId = 1L;
         double lat = 37.5;
         double lng = 127.0;
-        Location location = Location.of(BigDecimal.valueOf(lat), BigDecimal.valueOf(lng));
         MatchingCategory category = MatchingCategory.CHINESE;
         int participantCount = 2;
         Member fakeMember = Member.builder()
@@ -58,17 +50,15 @@ class MatchingTransactionServiceTest {
                 .build();
 
         given(participantStore.isAlreadyParticipating(memberId)).willReturn(false);
-        given(memberService.findMember(memberId)).willReturn(fakeMember);
+        given(memberService.findMemberForUpdate(memberId)).willReturn(fakeMember);
 
         // when
         matchingTransactionService.participateMatching(lat, lng, category, participantCount, memberId);
 
         // then
         verify(participantStore).isAlreadyParticipating(memberId);
-        verify(memberService).findMember(memberId);
+        verify(memberService).findMemberForUpdate(memberId);
         verify(matchingService).saveMatchingRequest(eq(memberId), eq(category), eq(participantCount), any());
-        verify(geoStore).addMemberLocation(category, participantCount, memberId, location);
-        verify(participantStore).transitionToParticipating(memberId);
-        verify(kafkaTemplate).send(eq(KafkaTopic.MATCHING_PARTICIPATE), any(MatchingParticipateEvent.class));
+        verify(eventPublisher).publishEvent(any(MatchingParticipateEvent.class));
     }
 }

--- a/mokakbob-api/src/test/java/com/mokakbob/member/service/auth/EmailAuthServiceTest.java
+++ b/mokakbob-api/src/test/java/com/mokakbob/member/service/auth/EmailAuthServiceTest.java
@@ -1,17 +1,18 @@
-package com.mokakbob.domain.member.service.auth;
+package com.mokakbob.member.service.auth;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.mokakbob.common.exception.DomainException;
-import com.mokakbob.domain.member.exception.MemberErrorCode;
-import com.mokakbob.domain.member.repository.EmailVerifyCodeStore;
+import com.mokakbob.auth.domain.EmailSender;
+import com.mokakbob.auth.domain.EmailVerifyCodeStore;
+import com.mokakbob.auth.exception.AuthApiErrorCode;
+import com.mokakbob.auth.service.EmailAuthService;
+import com.mokakbob.common.exception.exceptions.ApiException;
 import java.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -52,22 +53,7 @@ class EmailAuthServiceTest {
 
         // when & then
         assertThatThrownBy(() -> emailAuthService.sendEmail(email))
-                .isInstanceOf(DomainException.class)
-                .hasMessageContaining(MemberErrorCode.TOO_MANY_REQUEST.message());
-    }
-
-    @Test
-    void 이메일_전송_실패_시_인증_코드_삭제() {
-        // given
-        String email = "fail@example.com";
-        when(codeStore.hasCode(email)).thenReturn(false);
-        doThrow(new RuntimeException("이메일 전송 실패")).when(emailSender)
-                .sendEmail(eq(email), anyString(), anyString());
-
-        // when
-        emailAuthService.sendEmail(email);
-
-        // then
-        verify(codeStore).deleteCode(email);
+                .isInstanceOf(ApiException.class)
+                .hasMessageContaining(AuthApiErrorCode.TOO_MANY_REQUEST.message());
     }
 }

--- a/mokakbob-consumer/src/main/java/com/mokakbob/matching/consumer/MatchingFoundConsumer.java
+++ b/mokakbob-consumer/src/main/java/com/mokakbob/matching/consumer/MatchingFoundConsumer.java
@@ -22,9 +22,6 @@ public class MatchingFoundConsumer {
     public void consume(MatchingFoundEvent event) {
         log.info("[Kafka] MATCHING_FOUND 이벤트 수신: {}", event);
 
-        event.matched()
-                .forEach(memberId ->
-                        notificationCreateService.createNotification(event)
-                );
+        notificationCreateService.createNotification(event);
     }
 }

--- a/mokakbob-consumer/src/main/java/com/mokakbob/matching/consumer/MatchingFoundConsumer.java
+++ b/mokakbob-consumer/src/main/java/com/mokakbob/matching/consumer/MatchingFoundConsumer.java
@@ -20,8 +20,6 @@ public class MatchingFoundConsumer {
             containerFactory = "matchingFoundKafkaListenerContainerFactory"
     )
     public void consume(MatchingFoundEvent event) {
-        log.info("[Kafka] MATCHING_FOUND 이벤트 수신: {}", event);
-
         notificationCreateService.createNotification(event);
     }
 }

--- a/mokakbob-consumer/src/main/java/com/mokakbob/matching/exception/MatchingConsumerErrorCode.java
+++ b/mokakbob-consumer/src/main/java/com/mokakbob/matching/exception/MatchingConsumerErrorCode.java
@@ -8,6 +8,7 @@ public enum MatchingConsumerErrorCode implements ConsumerErrorCode {
     MATCHING_PARTICIPATE_CONSUMER_EXCEPTION(500, "C004", "매칭 참여 이벤트 처리 중 오류가 발생했습니다."),
     MATCHING_LOCK_ACQUIRE_FAILED(400, "C003", "이미 다른 매칭이 진행중입니다."),
     MATCHING_LOCK_INTERRUPTED(500, "C005", "매칭 락 대기 중 인터럽트가 발생했습니다."),
+    MATCHING_NOTIFICATION_SERIALIZE_FAILED(500, "C006", "매칭 이벤트 직렬화 실패.")
     ;
     private final int httpStatus;
     private final String customCode;

--- a/mokakbob-consumer/src/main/java/com/mokakbob/matching/service/NotificationCreateService.java
+++ b/mokakbob-consumer/src/main/java/com/mokakbob/matching/service/NotificationCreateService.java
@@ -7,7 +7,7 @@ import com.mokakbob.domain.matching.domain.Notification;
 import com.mokakbob.domain.matching.event.MatchingFoundEvent;
 import com.mokakbob.matching.common.exception.exceptions.ConsumerException;
 import com.mokakbob.matching.exception.MatchingConsumerErrorCode;
-import java.util.UUID;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -18,24 +18,26 @@ import org.springframework.stereotype.Service;
 public class NotificationCreateService {
 
     private static final long NOTIFICATION_TTL_SECONDS = 20L;
+    private static final String MATCHING_TYPE = "MATCHING_FOUND";
 
     private final NotificationStore notificationStore;
     private final ObjectMapper objectMapper;
 
     public void createNotification(MatchingFoundEvent event) {
-        event.matched().forEach(memberId -> {
-            Notification notification = Notification.builder()
-                    .id(generateId())
-                    .memberId(memberId)
-                    .type("MATCHING_FOUND")
-                    .payload(buildPayload(event))
-                    .build();
+        List<Notification> notifications = event.matched().stream()
+                .map(memberId -> Notification.builder()
+                        .memberId(memberId)
+                        .key(event.key())
+                        .type(MATCHING_TYPE)
+                        .payload(buildPayload(event))
+                        .build())
+                .toList();
 
-            notificationStore.save(notification, NOTIFICATION_TTL_SECONDS);
+        notificationStore.save(event.key(), notifications, NOTIFICATION_TTL_SECONDS);
 
-            log.info("알림 생성 완료 - memberId: {}, notificationId: {}",
-                    memberId, notification.getId());
-        });
+        notifications.forEach(n ->
+                log.info("방 생성 및 알림 생성 완료 - roomId: {}, memberId: {}", n.getKey(), n.getMemberId())
+        );
     }
 
     private String buildPayload(MatchingFoundEvent event) {
@@ -44,10 +46,5 @@ public class NotificationCreateService {
         } catch (JsonProcessingException e) {
             throw new ConsumerException(MatchingConsumerErrorCode.MATCHING_NOTIFICATION_SERIALIZE_FAILED);
         }
-    }
-
-
-    private long generateId() {
-        return UUID.randomUUID().getMostSignificantBits() & Long.MAX_VALUE;
     }
 }

--- a/mokakbob-consumer/src/main/java/com/mokakbob/matching/service/NotificationCreateService.java
+++ b/mokakbob-consumer/src/main/java/com/mokakbob/matching/service/NotificationCreateService.java
@@ -1,14 +1,53 @@
 package com.mokakbob.matching.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mokakbob.cache.NotificationStore;
+import com.mokakbob.domain.matching.domain.Notification;
 import com.mokakbob.domain.matching.event.MatchingFoundEvent;
+import com.mokakbob.matching.common.exception.exceptions.ConsumerException;
+import com.mokakbob.matching.exception.MatchingConsumerErrorCode;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class NotificationCreateService {
 
+    private static final long NOTIFICATION_TTL_SECONDS = 20L;
+
+    private final NotificationStore notificationStore;
+    private final ObjectMapper objectMapper;
+
     public void createNotification(MatchingFoundEvent event) {
-        // todo
+        event.matched().forEach(memberId -> {
+            Notification notification = Notification.builder()
+                    .id(generateId())
+                    .memberId(memberId)
+                    .type("MATCHING_FOUND")
+                    .payload(buildPayload(event))
+                    .build();
+
+            notificationStore.save(notification, NOTIFICATION_TTL_SECONDS);
+
+            log.info("알림 생성 완료 - memberId: {}, notificationId: {}",
+                    memberId, notification.getId());
+        });
+    }
+
+    private String buildPayload(MatchingFoundEvent event) {
+        try {
+            return objectMapper.writeValueAsString(event);
+        } catch (JsonProcessingException e) {
+            throw new ConsumerException(MatchingConsumerErrorCode.MATCHING_NOTIFICATION_SERIALIZE_FAILED);
+        }
+    }
+
+
+    private long generateId() {
+        return UUID.randomUUID().getMostSignificantBits() & Long.MAX_VALUE;
     }
 }

--- a/mokakbob-core/src/main/java/com/mokakbob/cache/NotificationStore.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/cache/NotificationStore.java
@@ -1,13 +1,10 @@
 package com.mokakbob.cache;
 
 import com.mokakbob.domain.matching.domain.Notification;
-import java.util.List;
 
 public interface NotificationStore {
 
     void save(Notification notification, long ttlSeconds);
     Notification findById(Long memberId, Long notificationId);
-    List<Notification> findAllByMemberId(Long memberId);
     void delete(Long memberId, Long notificationId);
-    void updateResponse(Long memberId, Long notificationId, boolean accepted);
 }

--- a/mokakbob-core/src/main/java/com/mokakbob/cache/NotificationStore.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/cache/NotificationStore.java
@@ -1,10 +1,10 @@
 package com.mokakbob.cache;
 
 import com.mokakbob.domain.matching.domain.Notification;
+import java.util.List;
 
 public interface NotificationStore {
 
-    void save(Notification notification, long ttlSeconds);
-    Notification findById(Long memberId, Long notificationId);
-    void delete(Long memberId, Long notificationId);
+    void save(String key, List<Notification> notifications, long ttlSeconds);
+    Notification findByMemberId(Long memberId);
 }

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/matching/domain/Notification.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/matching/domain/Notification.java
@@ -8,8 +8,8 @@ import lombok.Getter;
 @Builder
 public class Notification extends BaseEntity {
 
-    private final Long id;
     private final Long memberId;
+    private final String key;
     private final String type;
     private final String payload;
 

--- a/mokakbob-redis/src/main/java/com/mokakbob/common/exception/RedisErrorCode.java
+++ b/mokakbob-redis/src/main/java/com/mokakbob/common/exception/RedisErrorCode.java
@@ -1,0 +1,10 @@
+package com.mokakbob.common.exception;
+
+public interface RedisErrorCode {
+
+    int httpStatus();
+
+    String customCode();
+
+    String message();
+}

--- a/mokakbob-redis/src/main/java/com/mokakbob/common/exception/RedisException.java
+++ b/mokakbob-redis/src/main/java/com/mokakbob/common/exception/RedisException.java
@@ -1,0 +1,15 @@
+package com.mokakbob.common.exception;
+
+public class RedisException extends RuntimeException{
+
+    private final RedisErrorCode errorCode;
+
+    public RedisException(RedisErrorCode errorCode) {
+        super(errorCode.customCode() + ": " + errorCode.message());
+        this.errorCode = errorCode;
+    }
+
+    public RedisErrorCode redisErrorCode() {
+        return errorCode;
+    }
+}

--- a/mokakbob-redis/src/main/java/com/mokakbob/exception/NotificationErrorCode.java
+++ b/mokakbob-redis/src/main/java/com/mokakbob/exception/NotificationErrorCode.java
@@ -1,0 +1,35 @@
+package com.mokakbob.exception;
+
+import com.mokakbob.common.exception.RedisErrorCode;
+
+public enum NotificationErrorCode implements RedisErrorCode {
+
+    FAIL_REDIS_OPERATION(500, "R001", "Redis 조회 및 저장 오류가 발생했습니다."),
+    NOT_FOUND_NOTIFICATION(500, "R002", "저장된 알림이 없습니다."),
+    ;
+
+    private final int httpStatus;
+    private final String customCode;
+    private final String message;
+
+    NotificationErrorCode(int httpStatus, String customCode, String message) {
+        this.httpStatus = httpStatus;
+        this.customCode = customCode;
+        this.message = message;
+    }
+
+    @Override
+    public int httpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String customCode() {
+        return customCode;
+    }
+
+    @Override
+    public String message() {
+        return message;
+    }
+}

--- a/mokakbob-redis/src/main/java/com/mokakbob/matching/NotificationRedisStore.java
+++ b/mokakbob-redis/src/main/java/com/mokakbob/matching/NotificationRedisStore.java
@@ -6,6 +6,7 @@ import com.mokakbob.common.exception.RedisException;
 import com.mokakbob.domain.matching.domain.Notification;
 import com.mokakbob.exception.NotificationErrorCode;
 import java.time.Duration;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
@@ -14,35 +15,75 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class NotificationRedisStore implements NotificationStore {
 
-    private static final String NOTIFICATION_KEY = "notification:";
+    private static final String ROOM_KEY_PREFIX = "notification:room:";
+    private static final String MEMBER_KEY_PREFIX = "notification:member:";
 
     private final RedisTemplate<String, String> basicRedisTemplate;
     private final ObjectMapper objectMapper;
 
+    /**
+     * 매칭방 단위로 알림을 저장한다.
+     * <p>
+     * Redis 구조: - roomKey(Hash) (방 TTL 적용) - memberKey(String) (방 TTL과 동일)
+     *
+     * @param key           매칭방 식별자(멱등성 키)
+     * @param notifications 회원별 알림 리스트
+     * @param ttlSeconds    방 TTL(초)
+     */
     @Override
-    public void save(Notification notification, long ttlSeconds) {
+    public void save(String key, List<Notification> notifications, long ttlSeconds) {
+        String roomKey = ROOM_KEY_PREFIX + key;
+
         try {
-            String key = notificationKey(notification.getMemberId());
-            String notificationId = String.valueOf(notification.getId());
-            String value = objectMapper.writeValueAsString(notification);
+            for (Notification notification : notifications) {
+                String value = objectMapper.writeValueAsString(notification);
 
-            basicRedisTemplate.opsForHash()
-                    .put(key, notificationId, value);
+                basicRedisTemplate.opsForHash()
+                        .put(
+                                roomKey,
+                                String.valueOf(notification.getMemberId()),
+                                value
+                        );
 
-            basicRedisTemplate.expire(key, Duration.ofSeconds(ttlSeconds));
+                basicRedisTemplate.opsForValue()
+                        .set(
+                                MEMBER_KEY_PREFIX + notification.getMemberId(),
+                                roomKey,
+                                Duration.ofSeconds(ttlSeconds)
+                        );
+            }
+
+            basicRedisTemplate.expire(roomKey, Duration.ofSeconds(ttlSeconds));
         } catch (Exception e) {
             throw new RedisException(NotificationErrorCode.FAIL_REDIS_OPERATION);
         }
     }
 
+    /**
+     * memberId로 해당 회원의 알림을 조회한다.
+     * <p>
+     * - memberId → roomId 매핑 조회
+     * - roomId 해시에서 memberId 알림 JSON 조회
+     *
+     * @param memberId 회원 ID
+     * @return Notification 객체
+     * @throws RedisException 알림이 없거나 조회 실패 시
+     */
     @Override
-    public Notification findById(Long memberId, Long notificationId) {
+    public Notification findByMemberId(Long memberId) {
         try {
-            String key = notificationKey(memberId);
-            String value = (String) basicRedisTemplate.opsForHash()
-                    .get(key, String.valueOf(notificationId));
+            String roomId = basicRedisTemplate.opsForValue()
+                    .get(MEMBER_KEY_PREFIX + memberId);
 
-            if (value == null || value.isEmpty()) {
+            if (roomId == null) {
+                throw new RedisException(NotificationErrorCode.NOT_FOUND_NOTIFICATION);
+            }
+
+            String roomKey = ROOM_KEY_PREFIX + roomId;
+            String value = (String) basicRedisTemplate.opsForHash()
+                    .get(roomKey, String.valueOf(memberId));
+
+            if (value == null) {
                 throw new RedisException(NotificationErrorCode.NOT_FOUND_NOTIFICATION);
             }
 
@@ -50,15 +91,5 @@ public class NotificationRedisStore implements NotificationStore {
         } catch (Exception e) {
             throw new RedisException(NotificationErrorCode.FAIL_REDIS_OPERATION);
         }
-    }
-
-    @Override
-    public void delete(Long memberId, Long notificationId) {
-        basicRedisTemplate.opsForHash()
-                .delete(notificationKey(memberId), String.valueOf(notificationId));
-    }
-
-    private String notificationKey(Long memberId) {
-        return NOTIFICATION_KEY + memberId;
     }
 }

--- a/mokakbob-redis/src/main/java/com/mokakbob/matching/NotificationRedisStore.java
+++ b/mokakbob-redis/src/main/java/com/mokakbob/matching/NotificationRedisStore.java
@@ -48,8 +48,7 @@ public class NotificationRedisStore implements NotificationStore {
                 basicRedisTemplate.opsForValue()
                         .set(
                                 MEMBER_KEY_PREFIX + notification.getMemberId(),
-                                roomKey,
-                                Duration.ofSeconds(ttlSeconds)
+                                roomKey
                         );
             }
 

--- a/mokakbob-redis/src/main/java/com/mokakbob/matching/NotificationRedisStore.java
+++ b/mokakbob-redis/src/main/java/com/mokakbob/matching/NotificationRedisStore.java
@@ -5,6 +5,7 @@ import com.mokakbob.cache.NotificationStore;
 import com.mokakbob.common.exception.RedisException;
 import com.mokakbob.domain.matching.domain.Notification;
 import com.mokakbob.exception.NotificationErrorCode;
+import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -53,7 +54,7 @@ public class NotificationRedisStore implements NotificationStore {
             }
 
             basicRedisTemplate.expire(roomKey, Duration.ofSeconds(ttlSeconds));
-        } catch (Exception e) {
+        } catch (IOException e) {
             throw new RedisException(NotificationErrorCode.FAIL_REDIS_OPERATION);
         }
     }
@@ -78,16 +79,15 @@ public class NotificationRedisStore implements NotificationStore {
                 throw new RedisException(NotificationErrorCode.NOT_FOUND_NOTIFICATION);
             }
 
-            String roomKey = ROOM_KEY_PREFIX + roomId;
             String value = (String) basicRedisTemplate.opsForHash()
-                    .get(roomKey, String.valueOf(memberId));
+                    .get(roomId, String.valueOf(memberId));
 
             if (value == null) {
                 throw new RedisException(NotificationErrorCode.NOT_FOUND_NOTIFICATION);
             }
 
             return objectMapper.readValue(value, Notification.class);
-        } catch (Exception e) {
+        } catch (IOException e) {
             throw new RedisException(NotificationErrorCode.FAIL_REDIS_OPERATION);
         }
     }

--- a/mokakbob-redis/src/main/java/com/mokakbob/matching/NotificationRedisStore.java
+++ b/mokakbob-redis/src/main/java/com/mokakbob/matching/NotificationRedisStore.java
@@ -1,39 +1,64 @@
 package com.mokakbob.matching;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mokakbob.cache.NotificationStore;
+import com.mokakbob.common.exception.RedisException;
 import com.mokakbob.domain.matching.domain.Notification;
-import java.util.List;
+import com.mokakbob.exception.NotificationErrorCode;
+import java.time.Duration;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
 public class NotificationRedisStore implements NotificationStore {
 
+    private static final String NOTIFICATION_KEY = "notification:";
+
+    private final RedisTemplate<String, String> basicRedisTemplate;
+    private final ObjectMapper objectMapper;
+
     @Override
     public void save(Notification notification, long ttlSeconds) {
-        // todo
+        try {
+            String key = notificationKey(notification.getMemberId());
+            String notificationId = String.valueOf(notification.getId());
+            String value = objectMapper.writeValueAsString(notification);
+
+            basicRedisTemplate.opsForHash()
+                    .put(key, notificationId, value);
+
+            basicRedisTemplate.expire(key, Duration.ofSeconds(ttlSeconds));
+        } catch (Exception e) {
+            throw new RedisException(NotificationErrorCode.FAIL_REDIS_OPERATION);
+        }
     }
 
     @Override
     public Notification findById(Long memberId, Long notificationId) {
-        // todo
-        return null;
-    }
+        try {
+            String key = notificationKey(memberId);
+            String value = (String) basicRedisTemplate.opsForHash()
+                    .get(key, String.valueOf(notificationId));
 
-    @Override
-    public List<Notification> findAllByMemberId(Long memberId) {
-        // todo
-        return List.of();
+            if (value == null || value.isEmpty()) {
+                throw new RedisException(NotificationErrorCode.NOT_FOUND_NOTIFICATION);
+            }
+
+            return objectMapper.readValue(value, Notification.class);
+        } catch (Exception e) {
+            throw new RedisException(NotificationErrorCode.FAIL_REDIS_OPERATION);
+        }
     }
 
     @Override
     public void delete(Long memberId, Long notificationId) {
-        // todo
+        basicRedisTemplate.opsForHash()
+                .delete(notificationKey(memberId), String.valueOf(notificationId));
     }
 
-    @Override
-    public void updateResponse(Long memberId, Long notificationId, boolean accepted) {
-        // todo
+    private String notificationKey(Long memberId) {
+        return NOTIFICATION_KEY + memberId;
     }
 }


### PR DESCRIPTION
## 관련 이슈 번호
#61 closed

## 작업내용 25.09.02

* 전체적인 구조를 [Room: notification1(member1), notification2(member2)] - [Member: RoomId] 형식으로 변경하였습니다.(하나의 Room이 멤버별 알림을 가지고, 멤버가 해당 Room Id를 가지는 구조)


**해당 방식으로 설계한 이유**
* polling 방식으로 구현할 것임에 따라, 클라이언트는 매번 `memberId`만 넘겨주고 자신의 알림을 조회해야 합니다.
* 이때 알림은 roomId 기준으로 묶여 저장되므로, 클라이언트는 `memberId` 만으로 특정 알림을 조회할 수 없습니다.
* 따라서 memberId → roomId 매핑을 별도로 두었습니다.


### 매칭 알림 생성 시, TTL 기준점 및 멱등성 키 적용

1. 알림 구조 설계
  * 매칭 확정을 위한 이벤트 발행 시, 하나의 방(roomKey) 을 기준으로 알림을 관리하도록 하였습니다.
  * roomKey는 참여 시 발급한 `idempotencyKey` 로 구별 → 동일 이벤트 중복 처리 방지하였습니다.
  * `Notification` 객체가 idempotencyKey를 필드로 직접 보유하도록 구조 수정 → 알림 단위에서도 멱등성 보장하였습니다.
  * 방(roomKey) 내부에는 멤버별 알림(Hash)을 저장, 동시에 멤버 → 방 매핑(MEMBER_KEY_PREFIX + memberId)도 별도로 관리합니다.

2. TTL 관리
  * 방(roomKey)에 20초 TTL 적용 → 매칭 알림 유효 시간 만료 시 자동 삭제됩니다. 
  * 멤버 알림에는 TTL 을 적용하지 않았습니다. -> 방을 기준으로 멤버가 각각 매핑하고 있기에 방이 사라지면 해당 알림은 만료된 것으로 간주(방에만 TTL) -> 새로운 매핑에 참여 가능합니다.
  * 위와 같은 구조를 통해 member 간 TTL  불균형을 해결하였습니다.

## 작업 내용 25.09.01
* 매칭 확정을 위한 Consumer 로직 구현

### 알림 전용 저장소 구현
* 매칭 확정 알림을 위한 저장소를 구현했습니다. 
* TTL 값을 20초로 설정하여 20초 후 자동 만료되게 하였습니다.

### 참고사항
* 현재는 알림 생성까지만 처리하며, 이후 polling 방식으로 조회 기능을 붙일 예정입니다.