### PR TITLE
#63 [FEAT] 매칭 확정을 위한 polling api 구현

### DIFF
--- a/mokakbob-api/src/main/java/com/mokakbob/common/path/notification/NotificationPath.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/common/path/notification/NotificationPath.java
@@ -1,0 +1,6 @@
+package com.mokakbob.common.path.notification;
+
+public class NotificationPath {
+
+    public static final String POLL = "/api/v1/notifications";
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/common/path/notification/NotificationPath.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/common/path/notification/NotificationPath.java
@@ -2,5 +2,5 @@ package com.mokakbob.common.path.notification;
 
 public class NotificationPath {
 
-    public static final String POLL = "/api/v1/matching/notifications";
+    public static final String POLL_NOTIFICATION = "/api/v1/matching/notifications";
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/common/path/notification/NotificationPath.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/common/path/notification/NotificationPath.java
@@ -2,5 +2,5 @@ package com.mokakbob.common.path.notification;
 
 public class NotificationPath {
 
-    public static final String POLL = "/api/v1/notifications";
+    public static final String POLL = "/api/v1/matching/notifications";
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/notification/controller/NotificationController.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/notification/controller/NotificationController.java
@@ -1,7 +1,14 @@
 package com.mokakbob.notification.controller;
 
+import com.mokakbob.common.path.notification.NotificationPath;
+import com.mokakbob.domain.matching.domain.Notification;
+import com.mokakbob.global.resolver.annotation.MemberId;
+import com.mokakbob.notification.controller.response.NotificationResponse;
 import com.mokakbob.notification.service.NotificationService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -10,5 +17,11 @@ public class NotificationController {
 
     private final NotificationService notificationService;
 
-    // todo
+    @GetMapping(NotificationPath.POLL)
+    public ResponseEntity<NotificationResponse> getMatchingNotification(
+            @MemberId Long memberId
+    ) {
+        List<Notification> notifications = notificationService.getNotifications(memberId);
+        return ResponseEntity.ok(new NotificationResponse(notifications));
+    }
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/notification/controller/NotificationController.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/notification/controller/NotificationController.java
@@ -15,11 +15,11 @@ public class NotificationController {
 
     private final NotificationService notificationService;
 
-    @GetMapping(NotificationPath.POLL)
+    @GetMapping(NotificationPath.POLL_NOTIFICATION)
     public ResponseEntity<NotificationResponse> getMatchingNotification(
             @MemberId Long memberId
     ) {
-        return notificationService.getNotifications(memberId)
+        return notificationService.getNotification(memberId)
                 .map(NotificationResponse::of)
                 .map(ResponseEntity::ok)
                 .orElseGet(() -> ResponseEntity.ok(NotificationResponse.empty()));

--- a/mokakbob-api/src/main/java/com/mokakbob/notification/controller/NotificationController.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/notification/controller/NotificationController.java
@@ -5,7 +5,6 @@ import com.mokakbob.domain.matching.domain.Notification;
 import com.mokakbob.global.resolver.annotation.MemberId;
 import com.mokakbob.notification.controller.response.NotificationResponse;
 import com.mokakbob.notification.service.NotificationService;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -21,7 +20,7 @@ public class NotificationController {
     public ResponseEntity<NotificationResponse> getMatchingNotification(
             @MemberId Long memberId
     ) {
-        List<Notification> notifications = notificationService.getNotifications(memberId);
-        return ResponseEntity.ok(new NotificationResponse(notifications));
+        Notification notification = notificationService.getNotifications(memberId);
+        return ResponseEntity.ok(new NotificationResponse(notification));
     }
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/notification/controller/NotificationController.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/notification/controller/NotificationController.java
@@ -1,7 +1,6 @@
 package com.mokakbob.notification.controller;
 
 import com.mokakbob.common.path.notification.NotificationPath;
-import com.mokakbob.domain.matching.domain.Notification;
 import com.mokakbob.global.resolver.annotation.MemberId;
 import com.mokakbob.notification.controller.response.NotificationResponse;
 import com.mokakbob.notification.service.NotificationService;
@@ -20,7 +19,9 @@ public class NotificationController {
     public ResponseEntity<NotificationResponse> getMatchingNotification(
             @MemberId Long memberId
     ) {
-        Notification notification = notificationService.getNotifications(memberId);
-        return ResponseEntity.ok(new NotificationResponse(notification));
+        return notificationService.getNotifications(memberId)
+                .map(NotificationResponse::of)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.ok(NotificationResponse.empty()));
     }
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/notification/controller/response/NotificationResponse.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/notification/controller/response/NotificationResponse.java
@@ -1,0 +1,9 @@
+package com.mokakbob.notification.controller.response;
+
+import com.mokakbob.domain.matching.domain.Notification;
+import java.util.List;
+
+public record NotificationResponse(
+        List<Notification> notifications
+) {
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/notification/controller/response/NotificationResponse.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/notification/controller/response/NotificationResponse.java
@@ -1,9 +1,8 @@
 package com.mokakbob.notification.controller.response;
 
 import com.mokakbob.domain.matching.domain.Notification;
-import java.util.List;
 
 public record NotificationResponse(
-        List<Notification> notifications
+        Notification notifications
 ) {
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/notification/controller/response/NotificationResponse.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/notification/controller/response/NotificationResponse.java
@@ -3,6 +3,15 @@ package com.mokakbob.notification.controller.response;
 import com.mokakbob.domain.matching.domain.Notification;
 
 public record NotificationResponse(
-        Notification notifications
+        boolean hasNotification,
+        Notification notification
 ) {
+
+    public static NotificationResponse of(Notification notification) {
+        return new NotificationResponse(true, notification);
+    }
+
+    public static NotificationResponse empty() {
+        return new NotificationResponse(false, null);
+    }
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/notification/service/NotificationService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/notification/service/NotificationService.java
@@ -12,6 +12,6 @@ public class NotificationService {
     private final NotificationStore notificationStore;
 
     public Notification getNotifications(Long memberId) {
-        return notificationStore.findById(memberId);
+        return notificationStore.findByMemberId(memberId);
     }
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/notification/service/NotificationService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/notification/service/NotificationService.java
@@ -2,7 +2,6 @@ package com.mokakbob.notification.service;
 
 import com.mokakbob.cache.NotificationStore;
 import com.mokakbob.domain.matching.domain.Notification;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -12,7 +11,7 @@ public class NotificationService {
 
     private final NotificationStore notificationStore;
 
-    public List<Notification> getNotifications(Long memberId) {
-        return notificationStore.findAllByMemberId(memberId);
+    public Notification getNotifications(Long memberId) {
+        return notificationStore.findById(memberId);
     }
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/notification/service/NotificationService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/notification/service/NotificationService.java
@@ -12,7 +12,7 @@ public class NotificationService {
 
     private final NotificationStore notificationStore;
 
-    public Optional<Notification> getNotifications(Long memberId) {
+    public Optional<Notification> getNotification(Long memberId) {
         return notificationStore.findByMemberId(memberId);
     }
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/notification/service/NotificationService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/notification/service/NotificationService.java
@@ -1,6 +1,8 @@
 package com.mokakbob.notification.service;
 
 import com.mokakbob.cache.NotificationStore;
+import com.mokakbob.domain.matching.domain.Notification;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -10,5 +12,7 @@ public class NotificationService {
 
     private final NotificationStore notificationStore;
 
-    //todo
+    public List<Notification> getNotifications(Long memberId) {
+        return notificationStore.findAllByMemberId(memberId);
+    }
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/notification/service/NotificationService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/notification/service/NotificationService.java
@@ -2,6 +2,7 @@ package com.mokakbob.notification.service;
 
 import com.mokakbob.cache.NotificationStore;
 import com.mokakbob.domain.matching.domain.Notification;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -11,7 +12,7 @@ public class NotificationService {
 
     private final NotificationStore notificationStore;
 
-    public Notification getNotifications(Long memberId) {
+    public Optional<Notification> getNotifications(Long memberId) {
         return notificationStore.findByMemberId(memberId);
     }
 }

--- a/mokakbob-core/src/main/java/com/mokakbob/cache/NotificationStore.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/cache/NotificationStore.java
@@ -2,9 +2,10 @@ package com.mokakbob.cache;
 
 import com.mokakbob.domain.matching.domain.Notification;
 import java.util.List;
+import java.util.Optional;
 
 public interface NotificationStore {
 
     void save(String key, List<Notification> notifications, long ttlSeconds);
-    Notification findByMemberId(Long memberId);
+    Optional<Notification> findByMemberId(Long memberId);
 }

--- a/mokakbob-redis/src/main/java/com/mokakbob/matching/NotificationRedisStore.java
+++ b/mokakbob-redis/src/main/java/com/mokakbob/matching/NotificationRedisStore.java
@@ -8,6 +8,7 @@ import com.mokakbob.exception.NotificationErrorCode;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
@@ -70,23 +71,23 @@ public class NotificationRedisStore implements NotificationStore {
      * @throws RedisException 알림이 없거나 조회 실패 시
      */
     @Override
-    public Notification findByMemberId(Long memberId) {
+    public Optional<Notification> findByMemberId(Long memberId) {
         try {
             String roomId = basicRedisTemplate.opsForValue()
                     .get(MEMBER_KEY_PREFIX + memberId);
 
             if (roomId == null) {
-                throw new RedisException(NotificationErrorCode.NOT_FOUND_NOTIFICATION);
+                return Optional.empty();
             }
 
             String value = (String) basicRedisTemplate.opsForHash()
                     .get(roomId, String.valueOf(memberId));
 
             if (value == null) {
-                throw new RedisException(NotificationErrorCode.NOT_FOUND_NOTIFICATION);
+                return Optional.empty();
             }
 
-            return objectMapper.readValue(value, Notification.class);
+            return Optional.ofNullable(objectMapper.readValue(value, Notification.class));
         } catch (IOException e) {
             throw new RedisException(NotificationErrorCode.FAIL_REDIS_OPERATION);
         }


### PR DESCRIPTION
## 관련 이슈 번호
#63 closed

## 작업 내용 25.09.01
* 매칭 확정을 위한 polling api 구현

### Polling 구현 방식
* 클라이언트가 주기적으로 GET 요청을 보내도록 설계했습니다.
* Redis 에 저장된 알림을 조회하여 반환합니다.
* 서버는 단일 알림 조회 API만 제공하며, 실제 polling 주기 제어는 클라이언트에서 담당합니다.