### PR TITLE
#66 [FEAT] 매칭 로직 멱등성 키 구조 개선: 요청 키/매칭 키 분리

### DIFF
--- a/mokakbob-consumer/src/main/java/com/mokakbob/matching/service/MatchingParticipateService.java
+++ b/mokakbob-consumer/src/main/java/com/mokakbob/matching/service/MatchingParticipateService.java
@@ -100,8 +100,10 @@ public class MatchingParticipateService {
             List<Long> matched = buildMatchedGroup(memberId, candidates, event.participantCount());
             matched.forEach(participantStore::transitionToFound);
 
+            String matchKey = category.name() + "_" + participantCount + "_" + System.currentTimeMillis();
+
             MatchingFoundEvent matchingFoundEvent = new MatchingFoundEvent(
-                    idempotencyKey,
+                    matchKey,
                     category,
                     participantCount,
                     matched


### PR DESCRIPTION
## 관련 이슈 번호
#66 closed

## 작업 내용 25.09.04
* 매칭 Found 단계에서 matchKey(category + participantCount + timestamp)를 새로 생성하도록 수정하였습니다.

### 변경 이유
* memberId 기반 키는 개별 요청에 대한 멱등성을 보장하지만, 실제 매칭 결과는 그룹 단위(여러 memberId 묶음)로 관리되어야 한다는 생각이 들었습니다.
* 따라서 매칭 Found 시점에서 그룹을 대표할 수 있는 matchKey를 생성해주었습니다.
* matchKey를 생성해줌에 따라 동일한 그룹에 대해 중복 처리나 충돌을 방지할 수 있고, 로깅을 통한 대기열 추적이 더 쉬워졌습니다.
