### PR TITLE
#71 [FEAT] Dockerfile 생성 및 설정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# 1. 빌드 스테이지
+FROM gradle:7.6.4-jdk17 AS builder
+WORKDIR /app
+
+# Gradle 설정 파일 복사
+COPY build.gradle settings.gradle gradlew /app/
+COPY gradle /app/gradle
+
+# 전체 소스 복사 후 빌드
+COPY . /app
+RUN ./gradlew :mokakbob-api:clean :mokakbob-api:bootJar --no-daemon
+
+
+# 2. 실행 스테이지
+FROM eclipse-temurin:17-jdk
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y tzdata \
+    && ln -sf /usr/share/zoneinfo/Asia/Seoul /etc/localtime \
+    && echo "Asia/Seoul" > /etc/timezone \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /app/mokakbob-api/build/libs/*.jar app.jar
+
+ENTRYPOINT ["java", "-jar", "-Dspring.profiles.active=prod", "app.jar"]
+
+EXPOSE 8080


### PR DESCRIPTION
## 관련 이슈 번호
#71 closed

## 작업 내용 25.09.09

### 멀티 모듈 구조를 고려한 설정 적용
* mokakbob-api 모듈을 실행 모듈로 지정하여 bootJar로 패키징하였습니다.
* 다른 모듈(core, common, batch, kafka, redis)은 Gradle 의존성으로 포함되어 최종 JAR(app.jar)에 함께 반영되도록 하였습니다.

### 프로파일 기반 실행 고려
* Dockerfile 내 ENTRYPOINT에 `-Dspring.profiles.active=prod` 설정 → 운영 환경에 맞게 실행되도록 하였습니다.