### PR TITLE
#73 [FEAT] EC2 IAM Role 기반 인증 적용

### DIFF
--- a/mokakbob-api/src/main/java/com/mokakbob/member/config/S3Config.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/member/config/S3Config.java
@@ -4,20 +4,13 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 
 @Configuration
 @Profile("prod")
 public class S3Config {
-
-    @Value("${cloud.aws.credentials.accessKey}")
-    private String accessKey;
-
-    @Value("${cloud.aws.credentials.secretKey}")
-    private String secretKey;
 
     @Value("${cloud.aws.region.static}")
     private String region;
@@ -26,9 +19,7 @@ public class S3Config {
     public S3Client s3Client() {
         return S3Client.builder()
                 .region(Region.of(region))
-                .credentialsProvider(StaticCredentialsProvider.create(
-                        AwsBasicCredentials.create(accessKey, secretKey)
-                ))
+                .credentialsProvider(DefaultCredentialsProvider.create()) // IAM Role 자동 사용
                 .build();
     }
 }


### PR DESCRIPTION
## 관련 이슈 번호 
#73 closed 

## 작업 내용 25.09.10 
* EC2 IAM Role 기반 인증 적용

### S3 구현체 개선
* 기존 accessKey / secretKey 주입 방식 제거
* EC2 실행 시 IAM Role을 통해 자동으로 크레덴셜을 획득하도록 변경

### `.yml` 수정
* cloud.aws.credentials 블록 삭제
* cloud.aws.region.static, cloud.aws.s3.bucket만 유지