### PR TITLE
#77 [FEAT] EC2 배포 환경에서 OOM 발생 방지를 위한 JVM 메모리 옵션 적용

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,10 @@ RUN apt-get update && apt-get install -y tzdata \
 
 COPY --from=builder /app/mokakbob-api/build/libs/*.jar app.jar
 
-ENTRYPOINT ["java", "-jar", "-Dspring.profiles.active=prod", "app.jar"]
+# JVM 옵션 환경변수 (컨테이너 실행 시 오버라이드 가능)
+ENV JAVA_OPTS="-Xms512m -Xmx1024m"
+
+# JVM 옵션을 java 실행 시 적용
+ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -Dspring.profiles.active=prod -jar app.jar"]
 
 EXPOSE 8080


### PR DESCRIPTION
## 관련 이슈 번호
#77 closed

## 작업 내용 25.09.10
* Dockerfile 실행 스테이지에 JVM 메모리 옵션(`JAVA_OPTS`) 추가
   * 기본값: `-Xms512m -Xmx1024m`
   * 컨테이너 실행 시 `docker run -e JAVA_OPTS="..."` 형태로 오버라이드 가능
* ENTRYPOINT 수정 → `JAVA_OPTS`와 Spring profile(`prod`)이 함께 반영되도록 변경