### PR TITLE
#79 [FEAT] MSK EC2 연동을 위한 IAM Auth 라이브리 추가 및 kafka yml 설정 변경

### DIFF
--- a/mokakbob-api/build.gradle
+++ b/mokakbob-api/build.gradle
@@ -37,6 +37,8 @@ dependencies {
 
     // kafka
     implementation 'org.springframework.kafka:spring-kafka'
+
+    implementation "software.amazon.msk:aws-msk-iam-auth:1.1.7"
 }
 
 springBoot {


### PR DESCRIPTION
## 관련 이슈 번호
#79 closed

## 작업 내용 25.09.10
* Kafka 연결 시 `SASL_SSL` + `AWS_MSK_IAM` 방식 사용하도록 설정
* Gradle에 `aws-msk-iam-auth` 라이브러리 추가
* 기존 `PLAINTEXT` 연결 제거