### PR TITLE
#85 [FEAT] ElastiCache TLS 적용을 위한 RedisConfig 파일 설정 추가

### DIFF
--- a/mokakbob-redis/src/main/java/com/mokakbob/config/RedisConfig.java
+++ b/mokakbob-redis/src/main/java/com/mokakbob/config/RedisConfig.java
@@ -4,7 +4,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 
@@ -13,10 +16,28 @@ import org.springframework.data.redis.core.RedisTemplate;
 public class RedisConfig {
 
     @Bean
+    @Profile("local")
     public LettuceConnectionFactory redisConnectionFactory(
             @Value("${spring.data.redis.host}") String host,
             @Value("${spring.data.redis.port}") int port) {
         return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    @Profile("prod")
+    public LettuceConnectionFactory prodRedisConnectionFactory(
+            @Value("${spring.data.redis.host}") String host,
+            @Value("${spring.data.redis.port}") int port) {
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
+        config.setHostName(host);
+        config.setPort(port);
+
+        LettuceClientConfiguration clientConfig = LettuceClientConfiguration.builder()
+                .useSsl()
+                .disablePeerVerification()
+                .build();
+
+        return new LettuceConnectionFactory(config, clientConfig);
     }
 
     @Bean


### PR DESCRIPTION
## 관련 이슈 번호
#85 closed

## 작업 내용 25.09.11
* Profile 어노테이션을 사용하여 RedisConfig 설정
  * local 의 경우, 기존의 설정을 유지하도록 적용
  * prod 의 경우, tls 적용을 위한 설정 추가