### PR TITLE
#89 [FEAT] Participant 상태 전환 시 Redis 키 구조 개선

### DIFF
--- a/mokakbob-redis/src/main/java/com/mokakbob/matching/ParticipantRedisStore.java
+++ b/mokakbob-redis/src/main/java/com/mokakbob/matching/ParticipantRedisStore.java
@@ -3,7 +3,6 @@ package com.mokakbob.matching;
 import com.mokakbob.domain.matching.domain.vo.MatchingRequestStatus;
 import com.mokakbob.cache.ParticipantStore;
 import java.time.Duration;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
@@ -12,8 +11,8 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class ParticipantRedisStore implements ParticipantStore {
 
-    private static final String PARTICIPATE_KEY = "member:%d:matching:participate";
-    private static final String FOUND_KEY = "member:%d:matching:found";
+    private static final String PARTICIPATE_KEY = "member:{%d}:matching:participate";
+    private static final String FOUND_KEY       = "member:{%d}:matching:found";
     private static final Duration DEFAULT_TTL = Duration.ofHours(1);
     private static final String SHOW_EXIST = "1";
 
@@ -58,10 +57,8 @@ public class ParticipantRedisStore implements ParticipantStore {
     }
 
     private void deleteAllStates(Long memberId) {
-        basicRedisTemplate.delete(List.of(
-                participateKey(memberId),
-                foundKey(memberId)
-        ));
+        basicRedisTemplate.delete(participateKey(memberId));
+        basicRedisTemplate.delete(foundKey(memberId));
     }
 
     private String participateKey(Long memberId) {


### PR DESCRIPTION
## 관련 이슈 번호
#89 closed

## 작업 내용 25.09.11
* Redis 키 구조에 해시태그({}) 적용하여 동일 memberId 관련 키가 같은 슬롯에 매핑되도록 개선
    * member:%d:matching:participate → member:{%d}:matching:participate
    * member:%d:matching:found → member:{%d}:matching:found

* deleteAllStates()에서 delete(List.of(...)) 대신 단건 delete() 2회 호출 방식으로 변경
* Redis Cluster 환경에서 발생할 수 있는 CROSSSLOT 오류를 근본적으로 방지