### PR TITLE
#91 [CI/CD] GitHub Action Deploy

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,0 +1,63 @@
+name: CI/CD Deploy to EC2
+
+on:
+  push:
+    branches:
+      - main   # main 브랜치 push 시 실행
+
+jobs:
+  build-test-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      # 1. 소스코드 가져오기
+      - name: Checkout source
+        uses: actions/checkout@v3
+
+      # 2. JDK 세팅
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      # 3. Gradle 캐시
+      - name: Cache Gradle packages
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      # 4. 빌드 & 테스트 (CI 단계)
+      - name: Build and Test with Gradle
+        run: ./gradlew clean test --no-daemon
+
+      # 5. Docker Hub 로그인
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # 6. Docker 이미지 빌드 & 푸시 (CD 단계 시작)
+      - name: Build and Push Docker image
+        run: |
+          docker build -t ${{ secrets.DOCKERHUB_USERNAME }}/mokakbob:latest .
+          docker push ${{ secrets.DOCKERHUB_USERNAME }}/mokakbob:latest
+
+      # 7. EC2에 SSH 접속해서 배포
+      - name: Deploy to EC2
+        uses: appleboy/ssh-action@v0.1.10
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
+            docker pull ${{ secrets.DOCKERHUB_USERNAME }}/mokakbob:latest
+            docker stop mokakbob || true
+            docker rm mokakbob || true
+            docker run -d --name mokakbob -p 8080:8080 ${{ secrets.DOCKERHUB_USERNAME }}/mokakbob:latest


### PR DESCRIPTION
## 관련 이슈 번호
#91 closed

## 작업 내용 25.09.11
* GitHub Actions를 이용한 CI/CD 파이프라인 구축
* develop 브랜치 push 시 자동으로 트리거되도록 설정
* CI 단계: Gradle을 사용한 자동 빌드 및 테스트 실행 (품질 게이트 역할)
* CD 단계: 테스트 통과 시 Docker 이미지 빌드 및 Docker Hub 푸시 자동화