### PR TITLE
#97 [FEAT] 매칭 참여 시, 사용자의 위치 정보를 복구하는 로직 구현

### DIFF
--- a/mokakbob-api/src/main/java/com/mokakbob/matching/listener/MatchingParticipateEventListener.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/matching/listener/MatchingParticipateEventListener.java
@@ -20,10 +20,10 @@ public class MatchingParticipateEventListener {
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleMatchingParticipateEvent(MatchingParticipateEvent event) {
-        sendKafkaTopic(event);
-
         matchingWriterService.saveParticipantInfo(event);
         matchingWriterService.saveGeo(event);
+
+        sendKafkaTopic(event);
     }
 
     private void sendKafkaTopic(MatchingParticipateEvent event) {

--- a/mokakbob-consumer/src/main/java/com/mokakbob/matching/service/MatchingParticipateService.java
+++ b/mokakbob-consumer/src/main/java/com/mokakbob/matching/service/MatchingParticipateService.java
@@ -145,11 +145,17 @@ public class MatchingParticipateService {
         );
 
         List<Long> reserved = new ArrayList<>();
+        int requiredCount = event.participantCount() - 1;
 
         for (Long candidateId : nearby) {
             if (candidateId.equals(memberId)) {
                 continue;
             }
+
+            if (reserved.size() >= requiredCount) {
+                break;
+            }
+
             boolean success = geoStore.reserveMember(
                     event.category(),
                     event.participantCount(),

--- a/mokakbob-consumer/src/main/java/com/mokakbob/matching/service/MatchingParticipateService.java
+++ b/mokakbob-consumer/src/main/java/com/mokakbob/matching/service/MatchingParticipateService.java
@@ -119,7 +119,7 @@ public class MatchingParticipateService {
     private List<Long> buildMatchedGroup(Long delimiterMemberId, List<Long> candidates, int participantCount) {
         List<Long> matched = new ArrayList<>();
         matched.add(delimiterMemberId);
-        matched.addAll(candidates.subList(0, participantCount - 1));
+        matched.addAll(candidates.subList(0, Math.min(participantCount - 1, candidates.size())));
         return matched;
     }
 
@@ -139,7 +139,7 @@ public class MatchingParticipateService {
     private List<Long> findAndReserveCandidates(MatchingParticipateEvent event, Long memberId, Location location, String reserveId) {
         List<Long> nearby = geoStore.findNearbyMembers(
                 event.category(),
-                event.participantCount() - 1,
+                event.participantCount(),
                 location,
                 RADIUS_METERS
         );

--- a/mokakbob-redis/src/main/java/com/mokakbob/matching/ParticipantGeoRedisStore.java
+++ b/mokakbob-redis/src/main/java/com/mokakbob/matching/ParticipantGeoRedisStore.java
@@ -9,6 +9,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.geo.Circle;
 import org.springframework.data.geo.Distance;
 import org.springframework.data.geo.GeoResults;
@@ -29,6 +30,7 @@ import org.springframework.stereotype.Component;
  */
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class ParticipantGeoRedisStore implements ParticipantGeoStore {
 
     private static final String GEO_KEY = "matching:geo:%s:%d";
@@ -125,17 +127,25 @@ public class ParticipantGeoRedisStore implements ParticipantGeoStore {
         String geoKey = geoKey(category, count);
         String memberKey = memberKey(memberId);
 
+        List<Point> positions = basicRedisTemplate.opsForGeo()
+                .position(geoKey, memberKey);
+
+        if (positions == null || positions.isEmpty() || positions.get(0) == null) {
+            return false;
+        }
+        Point p = positions.get(0);
+
+        String reserveValue = memberKey + ":" + p.getX() + ":" + p.getY();
+
         Long removed = basicRedisTemplate.opsForGeo()
                 .remove(geoKey, memberKey);
-
         if (removed == null || removed == 0) {
             return false;
         }
 
         String reserveKey = RESERVE_KEY.formatted(reserveId);
         basicRedisTemplate.opsForList()
-                .rightPush(reserveKey, memberKey);
-
+                .rightPush(reserveKey, reserveValue);
         basicRedisTemplate.expire(reserveKey, ttl);
 
         return true;
@@ -153,24 +163,29 @@ public class ParticipantGeoRedisStore implements ParticipantGeoStore {
     @Override
     public void rollbackReservation(String reserveId, MatchingCategory category, int count) {
         String reserveKey = RESERVE_KEY.formatted(reserveId);
-        List<String> reserved = basicRedisTemplate.opsForList()
-                .range(reserveKey, 0, -1);
+        List<String> reserved = basicRedisTemplate.opsForList().range(reserveKey, 0, -1);
 
         if (reserved != null) {
-            reserved.forEach(value ->
-                    extractUserId(value).ifPresent(memberId ->
-                            getLocation(category, count, memberId).ifPresent(loc ->
-                                    basicRedisTemplate.opsForGeo().add(
-                                            geoKey(category, count),
-                                            new Point(
-                                                    loc.getLongitude().doubleValue(),
-                                                    loc.getLatitude().doubleValue()
-                                            ),
-                                            memberKey(memberId)
-                                    )
-                            )
-                    )
-            );
+            reserved.forEach(value -> {
+                String[] parts = value.split(":");
+                if (parts.length == 4) {
+                    String memberKey = parts[0] + ":" + parts[1];
+                    double lng = Double.parseDouble(parts[2]);
+                    double lat = Double.parseDouble(parts[3]);
+
+                    try {
+                        basicRedisTemplate.opsForGeo().add(
+                                geoKey(category, count),
+                                new Point(lng, lat),
+                                memberKey
+                        );
+                    } catch (Exception e) {
+                        log.error("Rollback GEO 추가 실패: key={}, lng={}, lat={}", memberKey, lng, lat, e);
+                    }
+                } else {
+                    log.warn("Rollback reservation format 오류: {}", value);
+                }
+            });
         }
 
         basicRedisTemplate.delete(reserveKey);


### PR DESCRIPTION
## 관련 이슈 번호
#97 closed

## 작업 내용 25.09.15

### 매칭 실패 시 롤백 로직 보완
* 문제점
   * 기존 reserveMember 로직이 멤버를 예약할 때 위치(좌표) 값을 저장하지 않아, 롤백 시 멤버를 원래 위치로 복구할 수 없는 문제가 있었습니다.



* 해결
   * 멤버를 예약(reserve)하는 시점에 해당 멤버의 위치 값을 함께 조회하여 임시 예약 리스트에 백업하도록 수정했습니다. 이를 통해 매칭에 실패하여 롤백이 실행될 때, 백업된 좌표를 이용해 모든 멤버를 원래의 대기열 위치로 정확하게 복원할 수 있도록 개선했습니다.

### 매칭 성공 시 후보자 선정 로직 최적화
* 문제점
   * findAndReserveCandidates 메소드가 주변 후보자를 찾을 때, 매칭에 필요한 인원수 이상으로 과도하게 예약하여 최종 선택되지 않은 멤버들이 일정 시간 동안 매칭 불가능한 상태(유령 상태)로 방치되는 문제가 있었습니다.



* 해결
   * 후보자를 예약하는 로직에 필요한 인원수(participantCount - 1)만큼만 예약하면 즉시 중단(break)하는 조건문을 추가했습니다. 이로써 선택되지 않은 나머지 후보자들은 애초에 예약되지 않고 대기열에 그대로 남아 즉시 다음 매칭에 참여할 수 있도록 로직을 최적화했습니다.