### PR TITLE
#103 [FEAT] 채팅 서버 구현(단일 서버)

### DIFF
--- a/mokakbob-api/build.gradle
+++ b/mokakbob-api/build.gradle
@@ -38,6 +38,9 @@ dependencies {
     // kafka
     implementation 'org.springframework.kafka:spring-kafka'
     implementation 'software.amazon.msk:aws-msk-iam-auth:1.1.9'
+
+    // websocket
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
 }
 
 springBoot {

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/config/SecurityConfig.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import com.mokakbob.auth.filter.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -39,7 +40,7 @@ public class SecurityConfig {
         http
                 // 기본 보안 설정 비활성화
                 .csrf(AbstractHttpConfigurer::disable)
-                .cors(AbstractHttpConfigurer::disable)
+                .cors(Customizer.withDefaults())
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .logout(AbstractHttpConfigurer::disable)
@@ -56,7 +57,8 @@ public class SecurityConfig {
                                 "/login/oauth2/**",                         // Oauth 콜백 URI
                                 "/favicon.ico",
                                 "/error",
-                                "/actuator/**"              // 헬스 체크 경로 추가
+                                "/actuator/**",              // 헬스 체크 경로 추가
+                                "/ws-connect/**"             // 웹소켓 경로 추가
                         ).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/mokakbob-api/src/main/java/com/mokakbob/auth/filter/JwtAuthenticationFilter.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/auth/filter/JwtAuthenticationFilter.java
@@ -43,7 +43,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         return uri.startsWith(PermitPath.AUTH_BASE) ||
                 uri.startsWith(PermitPath.EMAIL_BASE) ||
                 uri.startsWith(PermitPath.ADMIN_BASE) ||
-                uri.startsWith("/actuator") // 헬스체크 bypass
+                uri.startsWith("/actuator") || // 헬스체크 bypass
+                uri.startsWith("/ws-connect")  // 웹소켓
                 ;
     }
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/chat/config/WebSocketConfig.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/config/WebSocketConfig.java
@@ -1,0 +1,27 @@
+package com.mokakbob.chat.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        // 구독
+        registry.enableSimpleBroker("/sub");
+        // 발행
+        registry.setApplicationDestinationPrefixes("/pub");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws-connect")
+                .setAllowedOriginPatterns("*") // CORS 허용
+                .withSockJS(); // SockJS fallback 지원
+    }
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/chat/config/WebSocketConfig.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/config/WebSocketConfig.java
@@ -1,6 +1,9 @@
 package com.mokakbob.chat.config;
 
+import com.mokakbob.chat.handler.StompHandler;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
@@ -8,7 +11,10 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 
 @Configuration
 @EnableWebSocketMessageBroker
+@RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final StompHandler stompHandler;
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
@@ -23,5 +29,11 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         registry.addEndpoint("/ws-connect")
                 .setAllowedOriginPatterns("*") // CORS 허용
                 .withSockJS(); // SockJS fallback 지원
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        // ChannelInterceptor로 StompHandler 등록
+        registration.interceptors(stompHandler);
     }
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/chat/controller/ChatController.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/controller/ChatController.java
@@ -3,6 +3,7 @@ package com.mokakbob.chat.controller;
 import com.mokakbob.chat.controller.request.ChatMessageRequest;
 import com.mokakbob.chat.controller.response.ChatMessageResponse;
 import com.mokakbob.chat.service.ChatApiService;
+import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
@@ -15,8 +16,12 @@ public class ChatController {
     private final ChatApiService chatApiService;
 
     @MessageMapping("/chat/{roomId}")
-    public void sendMessage(@DestinationVariable Long roomId, ChatMessageRequest request) {
-        chatApiService.handleMessage(roomId, request.nickName(), request.content());
-        chatApiService.broadCastMessage(roomId, new ChatMessageResponse(roomId, request.nickName(), request.content()));
+    public void sendMessage(
+            @DestinationVariable Long roomId,
+            ChatMessageRequest request,
+            Principal principal
+    ) {
+        chatApiService.handleMessage(roomId, principal.getName(), request.content());
+        chatApiService.broadCastMessage(roomId, new ChatMessageResponse(roomId, principal.getName(), request.content()));
     }
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/chat/controller/ChatController.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/controller/ChatController.java
@@ -1,0 +1,22 @@
+package com.mokakbob.chat.controller;
+
+import com.mokakbob.chat.controller.request.ChatMessageRequest;
+import com.mokakbob.chat.controller.response.ChatMessageResponse;
+import com.mokakbob.chat.service.ChatApiService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.stereotype.Controller;
+
+@Controller
+@RequiredArgsConstructor
+public class ChatController {
+
+    private final ChatApiService chatApiService;
+
+    @MessageMapping("/chat/{roomId}")
+    public void sendMessage(@DestinationVariable Long roomId, ChatMessageRequest request) {
+        chatApiService.handleMessage(roomId, request.nickName(), request.content());
+        chatApiService.broadCastMessage(roomId, new ChatMessageResponse(roomId, request.nickName(), request.content()));
+    }
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/chat/controller/request/ChatMessageRequest.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/controller/request/ChatMessageRequest.java
@@ -1,0 +1,8 @@
+package com.mokakbob.chat.controller.request;
+
+public record ChatMessageRequest(
+        Long chatRoomId,
+        String nickName,
+        String content
+) {
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/chat/controller/request/ChatMessageRequest.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/controller/request/ChatMessageRequest.java
@@ -2,7 +2,6 @@ package com.mokakbob.chat.controller.request;
 
 public record ChatMessageRequest(
         Long chatRoomId,
-        String nickName,
         String content
 ) {
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/chat/controller/response/ChatMessageResponse.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/controller/response/ChatMessageResponse.java
@@ -1,0 +1,8 @@
+package com.mokakbob.chat.controller.response;
+
+public record ChatMessageResponse(
+        Long chatRoomId,
+        String nickName,
+        String content
+) {
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/chat/controller/response/ChatMessageResponse.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/controller/response/ChatMessageResponse.java
@@ -2,7 +2,7 @@ package com.mokakbob.chat.controller.response;
 
 public record ChatMessageResponse(
         Long chatRoomId,
-        String nickName,
+        String memberId,
         String content
 ) {
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/chat/exception/ChatErrorCode.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/exception/ChatErrorCode.java
@@ -1,0 +1,36 @@
+package com.mokakbob.chat.exception;
+
+import com.mokakbob.common.exception.exceptions.ApiErrorCode;
+
+public enum ChatErrorCode implements ApiErrorCode {
+
+    STOMP_JWT_MISSING(401, "CHAT_001", "Authorization 헤더가 없습니다."),
+    STOMP_JWT_INVALID(401, "CHAT_002", "유효하지 않은 JWT 토큰입니다."),
+    STOMP_JWT_EXPIRED(401, "CHAT_003", "JWT 토큰이 만료되었습니다.")
+    ;
+
+    private final int httpStatus;
+    private final String customCode;
+    private final String message;
+
+    ChatErrorCode(int httpStatus, String customCode, String message) {
+        this.httpStatus = httpStatus;
+        this.customCode = customCode;
+        this.message = message;
+    }
+
+    @Override
+    public int httpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String customCode() {
+        return customCode;
+    }
+
+    @Override
+    public String message() {
+        return message;
+    }
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/chat/handler/StompHandler.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/handler/StompHandler.java
@@ -9,6 +9,7 @@ import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
@@ -24,7 +25,11 @@ public class StompHandler implements ChannelInterceptor {
 
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
-        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+        StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+
+        if (accessor == null) {
+            return message;
+        }
 
         // connect 프레임일 경우, 인증 처리
         if (StompCommand.CONNECT.equals(accessor.getCommand())) {
@@ -32,6 +37,7 @@ public class StompHandler implements ChannelInterceptor {
 
             Authentication auth = validateToken(token);
             accessor.setUser(auth);
+            System.out.println(auth);
         }
 
         return message;

--- a/mokakbob-api/src/main/java/com/mokakbob/chat/handler/StompHandler.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/handler/StompHandler.java
@@ -1,0 +1,58 @@
+package com.mokakbob.chat.handler;
+
+import com.mokakbob.auth.infrastructure.JwtTokenProvider;
+import com.mokakbob.chat.exception.ChatErrorCode;
+import com.mokakbob.common.exception.exceptions.ApiException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class StompHandler implements ChannelInterceptor {
+
+    private static final String TOKEN_HEADER_NAME = "Authorization";
+    private static final String TOKEN_START_NAME = "Bearer ";
+    private static final int BEARER_PREFIX_LENGTH = "Bearer ".length();
+
+    private final JwtTokenProvider tokenProvider;
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+
+        // connect 프레임일 경우, 인증 처리
+        if (StompCommand.CONNECT.equals(accessor.getCommand())) {
+            String token = accessor.getFirstNativeHeader(TOKEN_HEADER_NAME);
+
+            Authentication auth = validateToken(token);
+            accessor.setUser(auth);
+        }
+
+        return message;
+    }
+
+    private Authentication validateToken(String token) {
+        if (token == null || !token.startsWith(TOKEN_START_NAME)) {
+            throw new ApiException(ChatErrorCode.STOMP_JWT_MISSING);
+        }
+
+        token = token.substring(BEARER_PREFIX_LENGTH); // "Bearer " 제거
+
+        if (tokenProvider.isAccessTokenExpired(token)) {
+            throw new ApiException(ChatErrorCode.STOMP_JWT_EXPIRED);
+        }
+
+        try {
+            Long memberId = tokenProvider.extractMemberId(token);
+            return tokenProvider.getAuthentication(memberId);
+        } catch (Exception e) {
+            throw new ApiException(ChatErrorCode.STOMP_JWT_INVALID);
+        }
+    }
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/chat/service/ChatApiService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/service/ChatApiService.java
@@ -2,8 +2,6 @@ package com.mokakbob.chat.service;
 
 import com.mokakbob.chat.controller.response.ChatMessageResponse;
 import com.mokakbob.domain.chat.service.ChatMessageService;
-import com.mokakbob.domain.member.domain.Member;
-import com.mokakbob.domain.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
@@ -17,12 +15,10 @@ public class ChatApiService {
 
     private final SimpMessagingTemplate messagingTemplate;
     private final ChatMessageService messageService;
-    private final MemberService memberService;
 
     @Transactional
-    public void handleMessage(Long roomId, String nickName, String content) {
-        Member member = memberService.findMemberByNickName(nickName);
-        messageService.saveChatMessage(roomId, member.getId(), content);
+    public void handleMessage(Long roomId, String memberId, String content) {
+        messageService.saveChatMessage(roomId, Long.valueOf(memberId), content);
     }
 
     public void broadCastMessage(Long roomId, ChatMessageResponse response) {

--- a/mokakbob-api/src/main/java/com/mokakbob/chat/service/ChatApiService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/service/ChatApiService.java
@@ -1,0 +1,31 @@
+package com.mokakbob.chat.service;
+
+import com.mokakbob.chat.controller.response.ChatMessageResponse;
+import com.mokakbob.domain.chat.service.ChatMessageService;
+import com.mokakbob.domain.member.domain.Member;
+import com.mokakbob.domain.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ChatApiService {
+
+    private static final String CHAT_SUB_ADDRESS = "/sub/chat/";
+
+    private final SimpMessagingTemplate messagingTemplate;
+    private final ChatMessageService messageService;
+    private final MemberService memberService;
+
+    @Transactional
+    public void handleMessage(Long roomId, String nickName, String content) {
+        Member member = memberService.findMemberByNickName(nickName);
+        messageService.saveChatMessage(roomId, member.getId(), content);
+    }
+
+    public void broadCastMessage(Long roomId, ChatMessageResponse response) {
+        messagingTemplate.convertAndSend(CHAT_SUB_ADDRESS + roomId, response);
+    }
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/global/config/WebConfig.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/global/config/WebConfig.java
@@ -5,6 +5,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
@@ -16,5 +17,13 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(authArgumentResolver);
+    }
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("http://localhost:3000")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowCredentials(true);
     }
 }

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/chat/domain/ChatMessage.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/chat/domain/ChatMessage.java
@@ -7,12 +7,16 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor
 public class ChatMessage extends BaseEntity {
 
     @Id

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/chat/service/ChatMessageService.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/chat/service/ChatMessageService.java
@@ -1,0 +1,25 @@
+package com.mokakbob.domain.chat.service;
+
+import com.mokakbob.domain.chat.domain.ChatMessage;
+import com.mokakbob.domain.chat.repository.ChatMessageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ChatMessageService {
+
+    private final ChatMessageRepository messageRepository;
+
+    @Transactional
+    public void saveChatMessage(Long roomId, Long senderId, String message) {
+        ChatMessage chatMessage = ChatMessage.builder()
+                .chatRoomId(roomId)
+                .senderId(senderId)
+                .message(message)
+                .build();
+
+        messageRepository.save(chatMessage);
+    }
+}

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/member/service/MemberService.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/member/service/MemberService.java
@@ -20,12 +20,6 @@ public class MemberService {
     private final MemberRepository memberRepository;
 
     @Transactional(readOnly = true)
-    public Member findMemberByNickName(String nickName) {
-        return memberRepository.findByNickname(nickName)
-                .orElseThrow(() -> new DomainException(MemberErrorCode.NOT_FOUND_MEMBER));
-    }
-
-    @Transactional(readOnly = true)
     public Optional<Member> findByNickName(String nickName) {
         return memberRepository.findByNickname(nickName);
     }

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/member/service/MemberService.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/member/service/MemberService.java
@@ -20,6 +20,12 @@ public class MemberService {
     private final MemberRepository memberRepository;
 
     @Transactional(readOnly = true)
+    public Member findMemberByNickName(String nickName) {
+        return memberRepository.findByNickname(nickName)
+                .orElseThrow(() -> new DomainException(MemberErrorCode.NOT_FOUND_MEMBER));
+    }
+
+    @Transactional(readOnly = true)
     public Optional<Member> findByNickName(String nickName) {
         return memberRepository.findByNickname(nickName);
     }
@@ -31,7 +37,8 @@ public class MemberService {
     }
 
     @Transactional
-    public Member createMember(String email, String passwordEnc, String nickName, String defaultImagePath, MemberPreference preference) {
+    public Member createMember(String email, String passwordEnc, String nickName, String defaultImagePath,
+                               MemberPreference preference) {
         validateDuplicateEmail(email);
         validateDuplicateNickName(nickName);
 
@@ -51,7 +58,7 @@ public class MemberService {
     @Transactional(readOnly = true)
     public Member findMember(Long memberId) {
         return memberRepository.findById(memberId)
-                .orElseThrow(()-> new DomainException(MemberErrorCode.NOT_FOUND_MEMBER));
+                .orElseThrow(() -> new DomainException(MemberErrorCode.NOT_FOUND_MEMBER));
     }
 
     @Transactional


### PR DESCRIPTION
## 관련 이슈 번호
#103 closed

## 작업 내용 25.10.29

### 웹소켓을 활용한 STOMP JWT 인증 파이프라인 구축
* 채팅 기능의 보안을 강화하기 위해 STOMP 웹소켓 레벨에서 JWT 인증을 구현. 기존에는 클라이언트가 보낸 닉네임을 통해 매번 확인했으나, 이제 서버가 검증한 Principal 정보를 통해 사용자를 식별.



* 인증 과정은 웹소켓의 특성에 따라 3단계로 분리되어 동작.

#### 1단계: HTTP 핸드셰이크 (연결 통로 개설)
* 클라이언트와 서버 간의 **순수 웹소켓 파이프(통로)**를 연결.

1. 클라이언트가 /ws-connect 엔드포인트로 웹소켓 연결을 위한 HTTP Upgrade 요청을 보냄.

2. SecurityConfig는 이 요청에 대해 permitAll() 설정으로 JWT 인증 없이 통과.

3. 서버는 HTTP 101 Switching Protocols 응답을 보내 연결 완료.

#### 2단계: STOMP 인증 (JWT 검증 및 Principal 등록)
* L1에서 열린 파이프를 통해 사용자(세션)의 신원을 STOMP 레벨에서 검증.

1. 웹소켓 파이프가 수립된 직후, 클라이언트는 JWT를 담은 CONNECT 프레임을 보냄.

2. StompHandler (ChannelInterceptor)가 이 CONNECT 메시지를 가로채 JWT 유효성 검증.

3. 인증에 성공하면 accessor.setUser(auth)를 호출하여, 웹소켓 세션에 해당 사용자의 **Principal 정보(신분증)**를 등록.

4. 서버는 CONNECTED 프레임을 전송하며 STOMP 연결 성공을 알림.

#### 3단계: Message Transfer (인증된 메시지 처리)
* 인증이 완료된 세션의 사용자만 메시지를 보낼 수 있도록 보장.

1. 인증이 완료된 클라이언트가 SEND 프레임을 보낼 때, JWT를 다시 전송할 필요가 없음.
2. StompHandler는 SEND 명령일 경우 JWT 검사를 건너뛰고 메시지를 통과시킵니다.
3. `@MessageMapping`이 적용된 컨트롤러는 **Principal**을 자동으로 주입받아, principal.getName()을 통해 인증된 사용자의 식별자를 사용.

----
### 웹소켓 JWT 인증 방식 트레이드-오프 비교

#### 방식1 : HTTP 핸드셰이크 인증
* 웹소켓 연결의 최초 HTTP Upgrade 요청 시점에 인증을 처리
* 서버 측에서는 HandshakeInterceptor를 구현하여 요청 헤더(예: 쿠키)에서 JWT를 추출해 검증
* 장점
  * 웹소켓 연결 자체가 수립되기 전에 인증되지 않은 악의적인 연결 시도를 차단 가능
* 단점
  * 웹소켓 연결되는 시점에 헤더에 JWT 를 담아서 줘야하는데, 웹소켓 헤더에는 JWT 삽입 불가.
  * 따라서 이를 구현하려면 JWT 를 쿼리 파라미터에 담아야하고, 보안에 취약해진다.

  
#### 방식 2: STOMP CONNECT 인증 (채택 방식)
* HTTP 핸드셰이크가 끝난 후, STOMP 프로토콜의 CONNECT 프레임 수신 시점에 인증을 처리.
* 서버 측에서는 **ChannelInterceptor (StompHandler)**를 구현하여 CONNECT 프레임 헤더의 JWT를 검증합니다.

* 장점
  * STOMP 표준 방식이며, 클라이언트가 connectHeaders를 통해 JWT를 깔끔하게 전송할 수 있어 구현이 가장 간편.
  * StompHandler 내에서 accessor.setUser()를 통해 Principal 객체를 STOMP 세션에 직접 통합할 수 있어, 이후 @MessageMapping에서 손쉽게 사용 가능.

* 단점
  * HTTP 엔드포인트(/ws-connect) 자체는 JWT 검증 없이 **permitAll()**로 열어두어야 함. 따라서, 이때의 보안 취약 가능성 있음
  
#### 방식 3: 매 메시지 인증
* 웹소켓 연결 수립 후에도, 클라이언트가 채팅 메시지를 보낼 때마다(STOMP SEND 프레임) 헤더에 JWT를 담아 보내고 서버가 매번 이를 검증하는 방식.

* 장점
  * 토큰 만료에 가장 즉각적으로 대응할 수 있음.

* 단점
  * Overhead 유발. 
  * 웹소켓은 상태 유지(Stateful) 연결인데, 매번 동일한 인증 작업을 반복하는 것은 비효율적.
  * 특히 대용량 트래픽 환경에서는 서버 리소스를 과도하게 소모.