### PR TITLE
#105 [FEAT] Redis Pub/Sub 기반 채팅 기능 구현 (다중 서버 확장)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,17 @@
+version: "3.9"
+
 services:
   redis:
     image: redis:7.2
     container_name: redis
     ports:
       - "6379:6379"
-    volumes:
-      - redis-data:/data
     command: ["redis-server", "--bind", "0.0.0.0", "--appendonly", "yes", "--protected-mode", "no"]
     restart: always
     healthcheck:
-      test: [ "CMD", "redis-cli", "ping" ]
+      test: ["CMD", "redis-cli", "ping"]
       interval: 2s
-      timeout: 1s
+      timeout: 2s
       retries: 20
 
   zookeeper:
@@ -34,10 +34,75 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT
       KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
     depends_on:
       - zookeeper
+    restart: always
+    healthcheck:
+      test: ["CMD", "bash", "-c", "echo > /dev/tcp/kafka/9092"]
+      interval: 3s
+      timeout: 2s
+      retries: 10
+
+  app1:
+    image: eclipse-temurin:17-jdk
+    container_name: app-8080
+    volumes:
+      - ./mokakbob-api/build/libs:/app
+    working_dir: /app
+    command: ["java", "-jar", "mokakbob-api-0.0.1-SNAPSHOT.jar", "--spring.profiles.active=local"]
+    ports:
+      - "8080:8080"
+    environment:
+      - SPRING_DATA_REDIS_HOST=redis
+      - SPRING_KAFKA_BOOTSTRAP_SERVERS=kafka:9092
+      - SERVER_PORT=8080
+    depends_on:
+      redis:
+        condition: service_healthy
+      kafka:
+        condition: service_healthy
+    restart: always
+
+  app2:
+    image: eclipse-temurin:17-jdk
+    container_name: app-8081
+    volumes:
+      - ./mokakbob-api/build/libs:/app
+    working_dir: /app
+    command: ["java", "-jar", "mokakbob-api-0.0.1-SNAPSHOT.jar", "--spring.profiles.active=local", "--server.port=8081"]
+    ports:
+      - "8081:8081"
+    environment:
+      - SPRING_DATA_REDIS_HOST=redis
+      - SPRING_KAFKA_BOOTSTRAP_SERVERS=kafka:9092
+      - SERVER_PORT=8081
+    depends_on:
+      redis:
+        condition: service_healthy
+      kafka:
+        condition: service_healthy
+    restart: always
+
+  app3:
+    image: eclipse-temurin:17-jdk
+    container_name: app-8082
+    volumes:
+      - ./mokakbob-api/build/libs:/app
+    working_dir: /app
+    command: ["java", "-jar", "mokakbob-api-0.0.1-SNAPSHOT.jar", "--spring.profiles.active=local", "--server.port=8082"]
+    ports:
+      - "8082:8082"
+    environment:
+      - SPRING_DATA_REDIS_HOST=redis
+      - SPRING_KAFKA_BOOTSTRAP_SERVERS=kafka:9092
+      - SERVER_PORT=8082
+    depends_on:
+      redis:
+        condition: service_healthy
+      kafka:
+        condition: service_healthy
     restart: always
 
 volumes:

--- a/mokakbob-api/src/main/java/com/mokakbob/chat/controller/ChatController.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/controller/ChatController.java
@@ -1,7 +1,6 @@
 package com.mokakbob.chat.controller;
 
 import com.mokakbob.domain.chat.pubsub.request.ChatMessageRequest;
-import com.mokakbob.domain.chat.pubsub.response.ChatMessageResponse;
 import com.mokakbob.chat.service.ChatApiService;
 import java.security.Principal;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +21,5 @@ public class ChatController {
             Principal principal
     ) {
         chatApiService.handleMessage(roomId, principal.getName(), request.content());
-        chatApiService.broadCastMessage(roomId, new ChatMessageResponse(roomId, principal.getName(), request.content()));
     }
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/chat/controller/ChatController.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/controller/ChatController.java
@@ -1,7 +1,7 @@
 package com.mokakbob.chat.controller;
 
-import com.mokakbob.chat.controller.request.ChatMessageRequest;
-import com.mokakbob.chat.controller.response.ChatMessageResponse;
+import com.mokakbob.domain.chat.pubsub.request.ChatMessageRequest;
+import com.mokakbob.domain.chat.pubsub.response.ChatMessageResponse;
 import com.mokakbob.chat.service.ChatApiService;
 import java.security.Principal;
 import lombok.RequiredArgsConstructor;

--- a/mokakbob-api/src/main/java/com/mokakbob/chat/pubsub/StompChatSubscriber.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/pubsub/StompChatSubscriber.java
@@ -1,0 +1,22 @@
+package com.mokakbob.chat.pubsub;
+
+import com.mokakbob.domain.chat.pubsub.ChatSubscriber;
+import com.mokakbob.domain.chat.pubsub.response.ChatMessageResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class StompChatSubscriber implements ChatSubscriber {
+
+    private static final String CHAT_SUB_ADDRESS = "/sub/chat/";
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @Override
+    public void handleMessage(String topic, ChatMessageResponse response) {
+        long roomId = Long.parseLong(topic.split("\\.")[1]);
+        messagingTemplate.convertAndSend(CHAT_SUB_ADDRESS + roomId, response);
+    }
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/chat/service/ChatApiService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/service/ChatApiService.java
@@ -1,9 +1,9 @@
 package com.mokakbob.chat.service;
 
-import com.mokakbob.chat.controller.response.ChatMessageResponse;
+import com.mokakbob.domain.chat.pubsub.ChatPublisher;
+import com.mokakbob.domain.chat.pubsub.response.ChatMessageResponse;
 import com.mokakbob.domain.chat.service.ChatMessageService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -11,9 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ChatApiService {
 
-    private static final String CHAT_SUB_ADDRESS = "/sub/chat/";
-
-    private final SimpMessagingTemplate messagingTemplate;
+    private final ChatPublisher chatPublisher;
     private final ChatMessageService messageService;
 
     @Transactional
@@ -22,6 +20,6 @@ public class ChatApiService {
     }
 
     public void broadCastMessage(Long roomId, ChatMessageResponse response) {
-        messagingTemplate.convertAndSend(CHAT_SUB_ADDRESS + roomId, response);
+        chatPublisher.publish(roomId, response);
     }
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/chat/service/ChatApiService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/service/ChatApiService.java
@@ -17,9 +17,6 @@ public class ChatApiService {
     @Transactional
     public void handleMessage(Long roomId, String memberId, String content) {
         messageService.saveChatMessage(roomId, Long.valueOf(memberId), content);
-    }
-
-    public void broadCastMessage(Long roomId, ChatMessageResponse response) {
-        chatPublisher.publish(roomId, response);
+        chatPublisher.publish(roomId, new ChatMessageResponse(roomId, memberId, content));
     }
 }

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/chat/pubsub/ChatPublisher.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/chat/pubsub/ChatPublisher.java
@@ -1,0 +1,7 @@
+package com.mokakbob.domain.chat.pubsub;
+
+import com.mokakbob.domain.chat.pubsub.response.ChatMessageResponse;
+
+public interface ChatPublisher {
+    void publish(Long roomId, ChatMessageResponse response);
+}

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/chat/pubsub/ChatSubscriber.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/chat/pubsub/ChatSubscriber.java
@@ -1,0 +1,7 @@
+package com.mokakbob.domain.chat.pubsub;
+
+import com.mokakbob.domain.chat.pubsub.response.ChatMessageResponse;
+
+public interface ChatSubscriber {
+    void handleMessage(String topic, ChatMessageResponse response);
+}

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/chat/pubsub/request/ChatMessageRequest.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/chat/pubsub/request/ChatMessageRequest.java
@@ -1,4 +1,4 @@
-package com.mokakbob.chat.controller.request;
+package com.mokakbob.domain.chat.pubsub.request;
 
 public record ChatMessageRequest(
         Long chatRoomId,

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/chat/pubsub/response/ChatMessageResponse.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/chat/pubsub/response/ChatMessageResponse.java
@@ -2,7 +2,7 @@ package com.mokakbob.domain.chat.pubsub.response;
 
 public record ChatMessageResponse(
         Long chatRoomId,
-        String memberId,
+        String senderId,
         String content
 ) {
 }

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/chat/pubsub/response/ChatMessageResponse.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/chat/pubsub/response/ChatMessageResponse.java
@@ -1,4 +1,4 @@
-package com.mokakbob.chat.controller.response;
+package com.mokakbob.domain.chat.pubsub.response;
 
 public record ChatMessageResponse(
         Long chatRoomId,

--- a/mokakbob-redis/src/main/java/com/mokakbob/chat/RedisChatPublisher.java
+++ b/mokakbob-redis/src/main/java/com/mokakbob/chat/RedisChatPublisher.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class RedisChatPublisher implements ChatPublisher {
 
-    private static final String CHANNEL_PREFIX = "chat/";
+    private static final String CHANNEL_PREFIX = "chat.";
 
     private final RedisTemplate<String, Object> redisTemplate;
 

--- a/mokakbob-redis/src/main/java/com/mokakbob/chat/RedisChatPublisher.java
+++ b/mokakbob-redis/src/main/java/com/mokakbob/chat/RedisChatPublisher.java
@@ -1,0 +1,21 @@
+package com.mokakbob.chat;
+
+import com.mokakbob.domain.chat.pubsub.ChatPublisher;
+import com.mokakbob.domain.chat.pubsub.response.ChatMessageResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisChatPublisher implements ChatPublisher {
+
+    private static final String CHANNEL_PREFIX = "chat/";
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    @Override
+    public void publish(Long roomId, ChatMessageResponse response) {
+        redisTemplate.convertAndSend(CHANNEL_PREFIX + roomId, response);
+    }
+}

--- a/mokakbob-redis/src/main/java/com/mokakbob/chat/RedisChatSubscriber.java
+++ b/mokakbob-redis/src/main/java/com/mokakbob/chat/RedisChatSubscriber.java
@@ -1,0 +1,29 @@
+package com.mokakbob.chat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mokakbob.domain.chat.pubsub.ChatSubscriber;
+import com.mokakbob.domain.chat.pubsub.response.ChatMessageResponse;
+import java.nio.charset.StandardCharsets;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisChatSubscriber implements MessageListener {
+
+    private final ObjectMapper objectMapper;
+    private final ChatSubscriber chatSubscriber;
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        try {
+            String channel = new String(message.getChannel(), StandardCharsets.UTF_8);
+            ChatMessageResponse payload = objectMapper.readValue(message.getBody(), ChatMessageResponse.class);
+            chatSubscriber.handleMessage(channel, payload);
+        } catch (Exception e) {
+            System.err.println("[RedisChatSubscriber] Failed: " + e.getMessage());
+        }
+    }
+}

--- a/mokakbob-redis/src/main/java/com/mokakbob/config/RedisConfig.java
+++ b/mokakbob-redis/src/main/java/com/mokakbob/config/RedisConfig.java
@@ -7,6 +7,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 @RequiredArgsConstructor
@@ -23,6 +25,16 @@ public class RedisConfig {
     public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
         RedisTemplate<String, Object> template = new RedisTemplate<>();
         template.setConnectionFactory(connectionFactory);
+
+        StringRedisSerializer keySerializer = new StringRedisSerializer();
+        GenericJackson2JsonRedisSerializer valueSerializer = new GenericJackson2JsonRedisSerializer();
+
+        template.setKeySerializer(keySerializer);
+        template.setHashKeySerializer(keySerializer);
+        template.setValueSerializer(valueSerializer);
+        template.setHashValueSerializer(valueSerializer);
+        template.afterPropertiesSet();
+
         return template;
     }
 }

--- a/mokakbob-redis/src/main/java/com/mokakbob/config/RedisConfig.java
+++ b/mokakbob-redis/src/main/java/com/mokakbob/config/RedisConfig.java
@@ -4,11 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
-import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 @RequiredArgsConstructor
@@ -19,22 +15,5 @@ public class RedisConfig {
             @Value("${spring.data.redis.host}") String host,
             @Value("${spring.data.redis.port}") int port) {
         return new LettuceConnectionFactory(host, port);
-    }
-
-    @Bean
-    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
-        RedisTemplate<String, Object> template = new RedisTemplate<>();
-        template.setConnectionFactory(connectionFactory);
-
-        StringRedisSerializer keySerializer = new StringRedisSerializer();
-        GenericJackson2JsonRedisSerializer valueSerializer = new GenericJackson2JsonRedisSerializer();
-
-        template.setKeySerializer(keySerializer);
-        template.setHashKeySerializer(keySerializer);
-        template.setValueSerializer(valueSerializer);
-        template.setHashValueSerializer(valueSerializer);
-        template.afterPropertiesSet();
-
-        return template;
     }
 }

--- a/mokakbob-redis/src/main/java/com/mokakbob/config/RedisPubSubConfig.java
+++ b/mokakbob-redis/src/main/java/com/mokakbob/config/RedisPubSubConfig.java
@@ -1,0 +1,27 @@
+package com.mokakbob.config;
+
+import com.mokakbob.chat.RedisChatSubscriber;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.listener.PatternTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+
+@Configuration
+@RequiredArgsConstructor
+public class RedisPubSubConfig {
+
+    private static final String CHAT_CHANNEL_PATTERN = "chat/*";
+
+    private final RedisConnectionFactory connectionFactory;
+    private final RedisChatSubscriber redisChatSubscriber;
+
+    @Bean
+    public RedisMessageListenerContainer redisMessageListenerContainer() {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+        container.addMessageListener(redisChatSubscriber, new PatternTopic(CHAT_CHANNEL_PATTERN));
+        return container;
+    }
+}

--- a/mokakbob-redis/src/main/java/com/mokakbob/config/RedisPubSubConfig.java
+++ b/mokakbob-redis/src/main/java/com/mokakbob/config/RedisPubSubConfig.java
@@ -12,7 +12,7 @@ import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 @RequiredArgsConstructor
 public class RedisPubSubConfig {
 
-    private static final String CHAT_CHANNEL_PATTERN = "chat/*";
+    private static final String CHAT_CHANNEL_PATTERN = "chat.*";
 
     private final RedisConnectionFactory connectionFactory;
     private final RedisChatSubscriber redisChatSubscriber;

--- a/mokakbob-redis/src/main/java/com/mokakbob/config/RedisTemplateConfig.java
+++ b/mokakbob-redis/src/main/java/com/mokakbob/config/RedisTemplateConfig.java
@@ -4,10 +4,28 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 public class RedisTemplateConfig {
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+
+        StringRedisSerializer keySerializer = new StringRedisSerializer();
+        GenericJackson2JsonRedisSerializer valueSerializer = new GenericJackson2JsonRedisSerializer();
+
+        template.setKeySerializer(keySerializer);
+        template.setHashKeySerializer(keySerializer);
+        template.setValueSerializer(valueSerializer);
+        template.setHashValueSerializer(valueSerializer);
+        template.afterPropertiesSet();
+
+        return template;
+    }
 
     @Bean
     public RedisTemplate<String, String> basicRedisTemplate(RedisConnectionFactory redisConnectionFactory) {


### PR DESCRIPTION
## 관련 이슈 번호
#105 closed

## 작업 내용 25.11.04

* WebSocket 다중 서버 구조 적용
  * 기존 단일 서버 구조에서 Redis Pub/Sub 기반 다중 서버 메시징 구조로 확장
  * 서버 간 실시간 메시지 동기화 및 브로드캐스팅 구현

### Pub/Sub 선택 이유
* 채팅 서비스의 핵심은 낮은 지연과 서버 간 실시간 동기화.
* 멀티 서버 환경에서 동일한 채팅방 사용자에게 동시에 메시지를 전달하기 위해 서버 간 브로드캐스팅 구조가 필요했고, Redis Pub/Sub 을 선택함.

### 개선
* 트랜잭션 커밋 이후 Publish 구조 적용
  * 현재는 `ChatApiService` 내에서 메시지를 저장한 직후 Redis에 publish()를 호출하고 있음.
  * 하지만 트랜잭션 커밋 이전에 예외가 발생하면 저장되지 않은 메시지가 전파될 수 있음.
  * 이벤트 기반 `publish` vs `TransactionSynchronizationManager.registerSynchronization()` 트레이드 오프 비교 필요

* `Redis Streams` 기반으로 확장 고려
  * `Redis Pub/Sub`은 비휘발성 메시지 저장이 불가능하므로, 장기적으로 메시지 로그 저장 및 재처리가 필요한 경우 `Redis Streams` 전환 고려