### PR TITLE
#107 [FEAT] 메트릭 수집 기능 추가 (Prometheus/Grafana 연동)

### DIFF
--- a/docker-compose-app.yml
+++ b/docker-compose-app.yml
@@ -1,3 +1,5 @@
+version: '3.8'
+
 services:
   redis:
     image: redis:7.2
@@ -11,6 +13,8 @@ services:
       interval: 2s
       timeout: 2s
       retries: 20
+    networks:
+      - monitoring-network
 
   zookeeper:
     image: confluentinc/cp-zookeeper:7.5.0
@@ -21,6 +25,8 @@ services:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
     restart: always
+    networks:
+      - monitoring-network
 
   kafka:
     image: confluentinc/cp-kafka:7.5.0
@@ -42,6 +48,8 @@ services:
       interval: 3s
       timeout: 2s
       retries: 10
+    networks:
+      - monitoring-network
 
   app1:
     image: eclipse-temurin:17-jdk

--- a/docker-compose-app.yml
+++ b/docker-compose-app.yml
@@ -1,7 +1,4 @@
-version: "3.9"
-
 services:
-  # Redis
   redis:
     image: redis:7.2
     container_name: redis
@@ -15,7 +12,6 @@ services:
       timeout: 2s
       retries: 20
 
-  # Zookeeper (Kafka 의존)
   zookeeper:
     image: confluentinc/cp-zookeeper:7.5.0
     container_name: zookeeper
@@ -26,7 +22,6 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
     restart: always
 
-  # Kafka
   kafka:
     image: confluentinc/cp-kafka:7.5.0
     container_name: kafka
@@ -48,7 +43,6 @@ services:
       timeout: 2s
       retries: 10
 
-  # Spring Boot Application 1
   app1:
     image: eclipse-temurin:17-jdk
     container_name: app-8080
@@ -68,8 +62,9 @@ services:
       kafka:
         condition: service_healthy
     restart: always
+    networks:
+      - monitoring-network
 
-  # Spring Boot Application 2
   app2:
     image: eclipse-temurin:17-jdk
     container_name: app-8081
@@ -89,8 +84,9 @@ services:
       kafka:
         condition: service_healthy
     restart: always
+    networks:
+      - monitoring-network
 
-  # Spring Boot Application 3
   app3:
     image: eclipse-temurin:17-jdk
     container_name: app-8082
@@ -110,40 +106,12 @@ services:
       kafka:
         condition: service_healthy
     restart: always
-
-  # Prometheus
-  prometheus:
-    image: prom/prometheus:latest
-    container_name: prometheus
-    ports:
-      - "9090:9090"
-    volumes:
-      - ./prometheus.yml:/etc/prometheus/prometheus.yml
-    command:
-      - --config.file=/etc/prometheus/prometheus.yml
-    depends_on:
-      - app1
-      - app2
-      - app3
-    restart: always
-
-  # Grafana
-  grafana:
-    image: grafana/grafana:latest
-    container_name: grafana
-    ports:
-      - "3000:3000"
-    environment:
-      - GF_SECURITY_ADMIN_USER=admin
-      - GF_SECURITY_ADMIN_PASSWORD=admin
-    depends_on:
-      - prometheus
-    restart: always
+    networks:
+      - monitoring-network
 
 volumes:
   redis-data:
 
 networks:
-  default:
-    name: monitoring-network
-    driver: bridge
+  monitoring-network:
+    external: true

--- a/docker-compose-monitoring.yml
+++ b/docker-compose-monitoring.yml
@@ -1,0 +1,37 @@
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+      - prometheus-data:/prometheus
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+    networks:
+      - monitoring-network
+    restart: always
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    volumes:
+      - grafana-data:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning
+    networks:
+      - monitoring-network
+    restart: always
+
+volumes:
+  prometheus-data:
+  grafana-data:
+
+networks:
+  monitoring-network:
+    external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 version: "3.9"
 
 services:
+  # Redis
   redis:
     image: redis:7.2
     container_name: redis
@@ -14,6 +15,7 @@ services:
       timeout: 2s
       retries: 20
 
+  # Zookeeper (Kafka 의존)
   zookeeper:
     image: confluentinc/cp-zookeeper:7.5.0
     container_name: zookeeper
@@ -24,6 +26,7 @@ services:
       ZOOKEEPER_TICK_TIME: 2000
     restart: always
 
+  # Kafka
   kafka:
     image: confluentinc/cp-kafka:7.5.0
     container_name: kafka
@@ -45,6 +48,7 @@ services:
       timeout: 2s
       retries: 10
 
+  # Spring Boot Application 1
   app1:
     image: eclipse-temurin:17-jdk
     container_name: app-8080
@@ -65,6 +69,7 @@ services:
         condition: service_healthy
     restart: always
 
+  # Spring Boot Application 2
   app2:
     image: eclipse-temurin:17-jdk
     container_name: app-8081
@@ -85,6 +90,7 @@ services:
         condition: service_healthy
     restart: always
 
+  # Spring Boot Application 3
   app3:
     image: eclipse-temurin:17-jdk
     container_name: app-8082
@@ -105,5 +111,39 @@ services:
         condition: service_healthy
     restart: always
 
+  # Prometheus
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+    depends_on:
+      - app1
+      - app2
+      - app3
+    restart: always
+
+  # Grafana
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    depends_on:
+      - prometheus
+    restart: always
+
 volumes:
   redis-data:
+
+networks:
+  default:
+    name: monitoring-network
+    driver: bridge

--- a/mokakbob-api/build.gradle
+++ b/mokakbob-api/build.gradle
@@ -41,6 +41,10 @@ dependencies {
 
     // websocket
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
+    // metrics
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 }
 
 springBoot {

--- a/mokakbob-api/src/main/java/com/mokakbob/chat/controller/ChatController.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/controller/ChatController.java
@@ -2,17 +2,23 @@ package com.mokakbob.chat.controller;
 
 import com.mokakbob.domain.chat.pubsub.request.ChatMessageRequest;
 import com.mokakbob.chat.service.ChatApiService;
+import com.mokakbob.metrix.ChatMetrics;
 import java.security.Principal;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.stereotype.Controller;
 
 @Controller
 @RequiredArgsConstructor
+@Slf4j
 public class ChatController {
 
+    private static final String METRICS_EVENT = "chat_send";
+
     private final ChatApiService chatApiService;
+    private final ChatMetrics chatMetrics;
 
     @MessageMapping("/chat/{roomId}")
     public void sendMessage(
@@ -20,6 +26,16 @@ public class ChatController {
             ChatMessageRequest request,
             Principal principal
     ) {
-        chatApiService.handleMessage(roomId, principal.getName(), request.content());
+        long start = System.currentTimeMillis();
+
+        try {
+            chatMetrics.countRequest(METRICS_EVENT);
+            chatApiService.handleMessage(roomId, principal.getName(), request.content());
+        } catch (Exception e) {
+            chatMetrics.countError(METRICS_EVENT);
+            throw e;
+        } finally {
+            chatMetrics.recordLatency(METRICS_EVENT, System.currentTimeMillis() - start);
+        }
     }
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/chat/handler/StompHandler.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/handler/StompHandler.java
@@ -3,6 +3,7 @@ package com.mokakbob.chat.handler;
 import com.mokakbob.auth.infrastructure.JwtTokenProvider;
 import com.mokakbob.chat.exception.ChatErrorCode;
 import com.mokakbob.common.exception.exceptions.ApiException;
+import com.mokakbob.metrix.ChatMetrics;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
@@ -22,6 +23,7 @@ public class StompHandler implements ChannelInterceptor {
     private static final int BEARER_PREFIX_LENGTH = "Bearer ".length();
 
     private final JwtTokenProvider tokenProvider;
+    private final ChatMetrics chatMetrics;
 
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
@@ -37,7 +39,9 @@ public class StompHandler implements ChannelInterceptor {
 
             Authentication auth = validateToken(token);
             accessor.setUser(auth);
-            System.out.println(auth);
+            chatMetrics.incrementSession();
+        } else if (StompCommand.DISCONNECT.equals(accessor.getCommand())) {
+            chatMetrics.decrementSession();
         }
 
         return message;

--- a/mokakbob-api/src/main/java/com/mokakbob/metrix/ApiMetrics.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/metrix/ApiMetrics.java
@@ -1,0 +1,41 @@
+package com.mokakbob.metrix;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.util.concurrent.TimeUnit;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ApiMetrics implements MetricsRecorder {
+
+    private final MeterRegistry registry;
+
+    public ApiMetrics(MeterRegistry registry) {
+        this.registry = registry;
+    }
+
+    @Override
+    public void countRequest(String apiName) {
+        Counter.builder(apiName + "_requests_total")
+                .description("Total API requests for " + apiName)
+                .register(registry)
+                .increment();
+    }
+
+    @Override
+    public void countError(String apiName) {
+        Counter.builder(apiName + "_errors_total")
+                .description("Total failed API requests for " + apiName)
+                .register(registry)
+                .increment();
+    }
+
+    @Override
+    public void recordLatency(String apiName, long millis) {
+        Timer.builder(apiName + "_response_time_seconds")
+                .description("Response time for " + apiName)
+                .register(registry)
+                .record(millis, TimeUnit.MILLISECONDS);
+    }
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/metrix/ChatMetrics.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/metrix/ChatMetrics.java
@@ -1,0 +1,69 @@
+package com.mokakbob.metrix;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ChatMetrics implements MetricsRecorder {
+
+    private static final String METRIC_ACTIVE_SESSIONS = "chat_active_sessions";
+    private static final String METRIC_MESSAGES_SENT_TOTAL = "chat_send_messages_sent_total";
+    private static final String METRIC_ERRORS_TOTAL = "chat_send_errors_total";
+    private static final String METRIC_LATENCY_SECONDS = "chat_send_message_latency_seconds";
+    private static final boolean ENABLE_HISTOGRAM = true;
+    private static final double[] PERCENTILES = {0.95, 0.99};
+
+    private final Counter messageSentCounter;
+    private final Counter errorCounter;
+    private final Timer latencyTimer;
+
+    private final AtomicInteger activeSessions = new AtomicInteger(0);
+
+    public ChatMetrics(MeterRegistry registry) {
+        Gauge.builder(METRIC_ACTIVE_SESSIONS, activeSessions, AtomicInteger::get)
+                .description("Number of active chat sessions")
+                .register(registry);
+
+        this.messageSentCounter = Counter.builder(METRIC_MESSAGES_SENT_TOTAL)
+                .description("Messages sent in chat event")
+                .register(registry);
+
+        this.errorCounter = Counter.builder(METRIC_ERRORS_TOTAL)
+                .description("Errors in chat event")
+                .register(registry);
+
+        this.latencyTimer = Timer.builder(METRIC_LATENCY_SECONDS)
+                .description("Chat message latency")
+                .publishPercentileHistogram(ENABLE_HISTOGRAM)
+                .publishPercentiles(PERCENTILES)
+                .register(registry);
+    }
+
+    @Override
+    public void countRequest(String eventName) {
+        messageSentCounter.increment();
+    }
+
+    @Override
+    public void countError(String eventName) {
+        errorCounter.increment();
+    }
+
+    @Override
+    public void recordLatency(String eventName, long millis) {
+        latencyTimer.record(millis, TimeUnit.MILLISECONDS);
+    }
+
+    public void incrementSession() {
+        activeSessions.incrementAndGet();
+    }
+
+    public void decrementSession() {
+        activeSessions.decrementAndGet();
+    }
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/metrix/MetricsRecorder.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/metrix/MetricsRecorder.java
@@ -1,0 +1,10 @@
+package com.mokakbob.metrix;
+
+public interface MetricsRecorder {
+
+    void countRequest(String name);
+
+    void countError(String name);
+
+    void recordLatency(String name, long millis);
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/metrix/config/MetricsConfig.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/metrix/config/MetricsConfig.java
@@ -1,0 +1,16 @@
+package com.mokakbob.metrix.config;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.boot.actuate.autoconfigure.metrics.MeterRegistryCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MetricsConfig {
+
+    @Bean
+    public MeterRegistryCustomizer<MeterRegistry> commonTags() {
+        return registry -> registry.config()
+                .commonTags("application", "mokakbob-api");
+    }
+}

--- a/mokakbob-api/src/main/resources/application.yml
+++ b/mokakbob-api/src/main/resources/application.yml
@@ -44,3 +44,20 @@ cloud:
       bucket: SSS
     region:
       static: ap-northeast-2
+
+# Prometheus + Actuator 설정 추가
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, metrics, prometheus  # prometheus endpoint 노출
+  endpoint:
+    prometheus:
+      access: unrestricted
+  metrics:
+    tags:
+      application: mokakbob  # 서비스 식별용 태그
+  prometheus:
+    metrics:
+      export:
+        enabled: true

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,11 @@
+global:
+  scrape_interval: 5s
+
+scrape_configs:
+  - job_name: 'mokakbob-apps'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets:
+          - 'app-8080:8080'
+          - 'app-8081:8081'
+          - 'app-8082:8082'

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -2,7 +2,7 @@ global:
   scrape_interval: 5s
 
 scrape_configs:
-  - job_name: 'mokakbob-apps'
+  - job_name: 'mokakbob-api'
     metrics_path: '/actuator/prometheus'
     static_configs:
       - targets:


### PR DESCRIPTION
## 관련 이슈 번호
* #107 closed

## 작업 내용 (25.11.07)
* 메트릭 수집 및 Grafana 연동
  * 서비스 전반의 성능 지표 수집 및 실시간 모니터링 체계를 구축하기 위해 `Spring Boot Actuator` + `Micrometer` + `Prometheus` + `Grafana` 연동 작업을 수행함.
  * 테스트 및 검증을 위해, 가장 트래픽이 많은 채팅 기능을 대상으로 메트릭 수집 구조를 먼저 적용함.

### `Prometheus` and `Grafana` 선택 이유
* `Prometheus`
  * `Spring Actuator` + `Micrometer`와의 기본 통합 지원.
  * Pull 기반 수집 방식으로 간단한 설정으로 안정적 지표 관리 가능.


* `Grafana`
  * `Prometheus` 데이터를 실시간 대시보드 형태로 시각화 가능.
  * 부하 테스트 중 응답 지연, 에러율, 처리량 등을 직관적으로 확인 가능.

### 적용 구조
~~~
[Spring Boot Chat Server]
   ↓
[Micrometer Metrics 수집 (ChatMetrics)]
   ↓
[Prometheus /actuator/prometheus scrape]
   ↓
[Grafana Dashboard 시각화]
~~~

### 채팅 기능에 메트릭 수집 기능 연동(테스트)
* 메트릭 수집 기능 연동 테스트를 위해 채팅 기능에 적용
* `ChatMetrics` 컴포넌트 추가하여 custom 진행
* 측정 지표 구성
  * `chat_active_sessions`, `chat_send_messages_sent_total`, `chat_send_errors_total`, `chat_send_message_latency_seconds`
* 측정 지표 구성에 따라 `Grafana` 대시보드 시각화 진행
<img width="732" height="283" alt="image" src="https://github.com/user-attachments/assets/56d648f1-8bd1-4dd3-b7c3-3e1adf3e8e2a" />
