### PR TITLE
#109 [FEAT] Redis Metrics 수집을 위한 Redis exporter 설정 추가 및 Prometheus 설정 수정

### DIFF
--- a/docker-compose-app.yml
+++ b/docker-compose-app.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   redis:
     image: redis:7.2
@@ -9,10 +7,27 @@ services:
     command: ["redis-server", "--bind", "0.0.0.0", "--appendonly", "yes", "--protected-mode", "no"]
     restart: always
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
-      interval: 2s
-      timeout: 2s
-      retries: 20
+      test: [ "CMD", "bash", "-c", "redis-cli -h 127.0.0.1 ping | grep PONG" ]
+      interval: 3s
+      timeout: 3s
+      retries: 10
+      start_period: 5s
+    networks:
+      - monitoring-network
+
+  redis-exporter:
+    image: oliver006/redis_exporter:latest
+    container_name: redis-exporter
+    ports:
+      - "9121:9121"
+    environment:
+      - REDIS_ADDR=redis://redis:6379
+      - REDIS_EXPORTER_CHECK_SINGLE_TARGET=true
+      - REDIS_EXPORTER_DEBUG=true
+    depends_on:
+      redis:
+        condition: service_healthy
+    restart: always
     networks:
       - monitoring-network
 

--- a/mokakbob-api/src/main/java/com/mokakbob/chat/controller/ChatController.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/controller/ChatController.java
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Controller;
 @Slf4j
 public class ChatController {
 
-    private static final String METRICS_EVENT = "chat_send";
+    private static final String METRICS_EVENT = "chat_send_message";
 
     private final ChatApiService chatApiService;
     private final ChatMetrics chatMetrics;

--- a/mokakbob-core/src/main/java/com/mokakbob/metrix/ChatMetrics.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/metrix/ChatMetrics.java
@@ -11,38 +11,71 @@ import org.springframework.stereotype.Component;
 @Component
 public class ChatMetrics implements MetricsRecorder {
 
+    // metric name
+    private static final String TAG_MODE_KEY = "mode";
+    private static final String TAG_MODE_VALUE = "pubsub";
+    private static final String PREFIX_SEND = "chat_send_message";
+    private static final String PREFIX_RECEIVE = "chat_receive_message";
     private static final String METRIC_ACTIVE_SESSIONS = "chat_active_sessions";
-    private static final String METRIC_MESSAGES_SENT_TOTAL = "chat_send_messages_sent_total";
-    private static final String METRIC_ERRORS_TOTAL = "chat_send_errors_total";
-    private static final String METRIC_LATENCY_SECONDS = "chat_send_message_latency_seconds";
+    private static final String SUFFIX_MESSAGES_TOTAL = "_sent_total";
+    private static final String SUFFIX_ERRORS_TOTAL = "_errors_total";
+    private static final String SUFFIX_LATENCY_SECONDS = "_latency_seconds";
+
+    // metric description
+    private static final String DESC_ACTIVE_SESSIONS = "Number of active chat sessions";
+    private static final String DESC_SEND_TOTAL = "Total number of chat messages sent";
+    private static final String DESC_SEND_ERRORS = "Number of errors occurred during sending chat messages";
+    private static final String DESC_SEND_LATENCY = "Latency for sending chat messages";
+    private static final String DESC_RECEIVE_ERRORS = "Number of errors occurred during receiving chat messages";
+    private static final String DESC_RECEIVE_LATENCY = "Latency for receiving chat messages";
+
+    // timer
     private static final boolean ENABLE_HISTOGRAM = true;
     private static final double[] PERCENTILES = {0.95, 0.99};
 
-    private final Counter messageSentCounter;
-    private final Counter errorCounter;
-    private final Timer latencyTimer;
-
+    // metric object
     private final AtomicInteger activeSessions = new AtomicInteger(0);
 
+    private final Counter sendCounter;
+    private final Counter sendErrorCounter;
+    private final Timer sendLatencyTimer;
+
+    private final Counter receiveErrorCounter;
+    private final Timer receiveLatencyTimer;
+
     public ChatMetrics(MeterRegistry registry) {
+        // Active sessions
         Gauge.builder(METRIC_ACTIVE_SESSIONS, activeSessions, AtomicInteger::get)
-                .description("Number of active chat sessions")
-                .tag("mode", "pubsub")
+                .description(DESC_ACTIVE_SESSIONS)
+                .tag(TAG_MODE_KEY, TAG_MODE_VALUE)
                 .register(registry);
 
-        this.messageSentCounter = Counter.builder(METRIC_MESSAGES_SENT_TOTAL)
-                .description("Messages sent in chat event")
-                .tag("mode", "pubsub")
-                .register(registry);
+        // Send metrics
+        this.sendCounter = buildCounter(registry,
+                PREFIX_SEND + SUFFIX_MESSAGES_TOTAL, DESC_SEND_TOTAL);
+        this.sendErrorCounter = buildCounter(registry,
+                PREFIX_SEND + SUFFIX_ERRORS_TOTAL, DESC_SEND_ERRORS);
+        this.sendLatencyTimer = buildTimer(registry,
+                PREFIX_SEND + SUFFIX_LATENCY_SECONDS, DESC_SEND_LATENCY);
 
-        this.errorCounter = Counter.builder(METRIC_ERRORS_TOTAL)
-                .description("Errors in chat event")
-                .tag("mode", "pubsub")
-                .register(registry);
+        // Receive metrics
+        this.receiveErrorCounter = buildCounter(registry,
+                PREFIX_RECEIVE + SUFFIX_ERRORS_TOTAL, DESC_RECEIVE_ERRORS);
+        this.receiveLatencyTimer = buildTimer(registry,
+                PREFIX_RECEIVE + SUFFIX_LATENCY_SECONDS, DESC_RECEIVE_LATENCY);
+    }
 
-        this.latencyTimer = Timer.builder(METRIC_LATENCY_SECONDS)
-                .description("Chat message latency")
-                .tag("mode", "pubsub")
+    private Counter buildCounter(MeterRegistry registry, String name, String description) {
+        return Counter.builder(name)
+                .description(description)
+                .tag(TAG_MODE_KEY, TAG_MODE_VALUE)
+                .register(registry);
+    }
+
+    private Timer buildTimer(MeterRegistry registry, String name, String description) {
+        return Timer.builder(name)
+                .description(description)
+                .tag(TAG_MODE_KEY, TAG_MODE_VALUE)
                 .publishPercentileHistogram(ENABLE_HISTOGRAM)
                 .publishPercentiles(PERCENTILES)
                 .register(registry);
@@ -50,17 +83,27 @@ public class ChatMetrics implements MetricsRecorder {
 
     @Override
     public void countRequest(String eventName) {
-        messageSentCounter.increment();
+        if (PREFIX_SEND.equals(eventName)) {
+            sendCounter.increment();
+        }
     }
 
     @Override
     public void countError(String eventName) {
-        errorCounter.increment();
+        if (PREFIX_SEND.equals(eventName)) {
+            sendErrorCounter.increment();
+        } else if (PREFIX_RECEIVE.equals(eventName)) {
+            receiveErrorCounter.increment();
+        }
     }
 
     @Override
     public void recordLatency(String eventName, long millis) {
-        latencyTimer.record(millis, TimeUnit.MILLISECONDS);
+        if (PREFIX_SEND.equals(eventName)) {
+            sendLatencyTimer.record(millis, TimeUnit.MILLISECONDS);
+        } else if (PREFIX_RECEIVE.equals(eventName)) {
+            receiveLatencyTimer.record(millis, TimeUnit.MILLISECONDS);
+        }
     }
 
     public void incrementSession() {

--- a/mokakbob-redis/src/main/java/com/mokakbob/chat/RedisChatSubscriber.java
+++ b/mokakbob-redis/src/main/java/com/mokakbob/chat/RedisChatSubscriber.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class RedisChatSubscriber implements MessageListener {
 
-    private static final String METRICS_EVENT = "chat_receive";
+    private static final String METRICS_EVENT = "chat_receive_message";
 
     private final ObjectMapper objectMapper;
     private final ChatSubscriber chatSubscriber;

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -9,3 +9,8 @@ scrape_configs:
           - 'app-8080:8080'
           - 'app-8081:8081'
           - 'app-8082:8082'
+
+  - job_name: 'redis'
+    static_configs:
+      - targets:
+          - 'redis-exporter:9121'


### PR DESCRIPTION
## 관련 이슈 번호
* #109  closed

## 작업 내용 (25.11.10)
- `Redis Exporter` 컨테이너 추가 (oliver006/redis_exporter:latest)
- `Prometheus`에서 `Redis` 메트릭 수집 설정 추가 (`redis-exporter:9121`)
- monitoring-network를 통해 Redis <-> Exporter <-> Prometheus 네트워크 연결 확인
- Prometheus `prometheus.yml` 수정 (job_name: redis)
- `Redis` 모니터링 지표 정상 수집 확인 (`redis_up 1`)