### PR TITLE
#115 [FEAT] 채팅방 입장 api 구현

### DIFF
--- a/mokakbob-api/src/main/java/com/mokakbob/chat/controller/ChatController.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/controller/ChatController.java
@@ -1,39 +1,30 @@
 package com.mokakbob.chat.controller;
 
-import com.mokakbob.domain.chat.pubsub.request.ChatMessageRequest;
-import com.mokakbob.chat.service.ChatApiService;
-import com.mokakbob.metrix.ChatMetrics;
-import java.security.Principal;
+import com.mokakbob.chat.controller.request.ChatRoomEnterRequest;
+import com.mokakbob.chat.controller.response.ChatRoomEnterResponse;
+import com.mokakbob.common.path.chat.ChatPath;
+import com.mokakbob.global.resolver.annotation.MemberId;
 import lombok.RequiredArgsConstructor;
-import org.springframework.messaging.handler.annotation.DestinationVariable;
-import org.springframework.messaging.handler.annotation.MessageMapping;
-import org.springframework.stereotype.Controller;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
+@RestController
 @RequiredArgsConstructor
 public class ChatController {
 
-    private static final String METRICS_EVENT = "chat_send_message";
-
-    private final ChatApiService chatApiService;
-    private final ChatMetrics chatMetrics;
-
-    @MessageMapping("/chat/{roomId}")
-    public void sendMessage(
-            @DestinationVariable Long roomId,
-            ChatMessageRequest request,
-            Principal principal
+    @GetMapping(ChatPath.ENTER)
+    public ResponseEntity<ChatRoomEnterResponse> enterRoom(
+            @RequestBody ChatRoomEnterRequest request,
+            @MemberId Long memberId
     ) {
-        long sentAt = System.currentTimeMillis();
 
-        try {
-            chatMetrics.countRequest(METRICS_EVENT);
-            chatApiService.handleMessage(roomId, principal.getName(), request.content(), sentAt);
-        } catch (Exception e) {
-            chatMetrics.countError(METRICS_EVENT);
-            throw e;
-        } finally {
-            chatMetrics.recordLatency(METRICS_EVENT, System.currentTimeMillis() - sentAt);
-        }
+        return ResponseEntity.ok(new ChatRoomEnterResponse(
+                request.roomId(),
+                ChatPath.WS,
+                ChatPath.PUB,
+                ChatPath.SUB
+        ));
     }
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/chat/controller/ChatController.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/controller/ChatController.java
@@ -2,7 +2,9 @@ package com.mokakbob.chat.controller;
 
 import com.mokakbob.chat.controller.request.ChatRoomEnterRequest;
 import com.mokakbob.chat.controller.response.ChatRoomEnterResponse;
+import com.mokakbob.chat.service.ChatApiService;
 import com.mokakbob.common.path.chat.ChatPath;
+import com.mokakbob.domain.chat.domain.ChatRoom;
 import com.mokakbob.global.resolver.annotation.MemberId;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -14,14 +16,17 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class ChatController {
 
+    private final ChatApiService chatApiService;
+
     @GetMapping(ChatPath.ENTER)
     public ResponseEntity<ChatRoomEnterResponse> enterRoom(
             @RequestBody ChatRoomEnterRequest request,
             @MemberId Long memberId
     ) {
+        ChatRoom room = chatApiService.findChatRoom(request.roomId(), memberId);
 
         return ResponseEntity.ok(new ChatRoomEnterResponse(
-                request.roomId(),
+                room.getId(),
                 ChatPath.WS,
                 ChatPath.PUB,
                 ChatPath.SUB

--- a/mokakbob-api/src/main/java/com/mokakbob/chat/controller/ChatMessageController.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/controller/ChatMessageController.java
@@ -1,0 +1,39 @@
+package com.mokakbob.chat.controller;
+
+import com.mokakbob.domain.chat.pubsub.request.ChatMessageRequest;
+import com.mokakbob.chat.service.ChatApiService;
+import com.mokakbob.metrix.ChatMetrics;
+import java.security.Principal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.stereotype.Controller;
+
+@Controller
+@RequiredArgsConstructor
+public class ChatMessageController {
+
+    private static final String METRICS_EVENT = "chat_send_message";
+
+    private final ChatApiService chatApiService;
+    private final ChatMetrics chatMetrics;
+
+    @MessageMapping("/chat/{roomId}")
+    public void sendMessage(
+            @DestinationVariable Long roomId,
+            ChatMessageRequest request,
+            Principal principal
+    ) {
+        long sentAt = System.currentTimeMillis();
+
+        try {
+            chatMetrics.countRequest(METRICS_EVENT);
+            chatApiService.handleMessage(roomId, principal.getName(), request.content(), sentAt);
+        } catch (Exception e) {
+            chatMetrics.countError(METRICS_EVENT);
+            throw e;
+        } finally {
+            chatMetrics.recordLatency(METRICS_EVENT, System.currentTimeMillis() - sentAt);
+        }
+    }
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/chat/controller/request/ChatRoomEnterRequest.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/controller/request/ChatRoomEnterRequest.java
@@ -1,0 +1,6 @@
+package com.mokakbob.chat.controller.request;
+
+public record ChatRoomEnterRequest(
+    Long roomId
+) {
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/chat/controller/response/ChatRoomEnterResponse.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/controller/response/ChatRoomEnterResponse.java
@@ -1,0 +1,9 @@
+package com.mokakbob.chat.controller.response;
+
+public record ChatRoomEnterResponse(
+        Long roomId,
+        String wsUrl,
+        String pub,
+        String sub
+) {
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/chat/service/ChatApiService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/service/ChatApiService.java
@@ -1,8 +1,12 @@
 package com.mokakbob.chat.service;
 
+import com.mokakbob.domain.chat.domain.ChatRoom;
 import com.mokakbob.domain.chat.pubsub.ChatPublisher;
 import com.mokakbob.domain.chat.pubsub.response.ChatMessageResponse;
 import com.mokakbob.domain.chat.service.ChatMessageService;
+import com.mokakbob.domain.chat.service.ChatService;
+import com.mokakbob.domain.matching.domain.Matching;
+import com.mokakbob.domain.matching.service.MatchingParticipateService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,10 +17,21 @@ public class ChatApiService {
 
     private final ChatPublisher chatPublisher;
     private final ChatMessageService messageService;
+    private final ChatService chatService;
+    private final MatchingParticipateService participateService;
 
     @Transactional
     public void handleMessage(Long roomId, String memberId, String content, long sendAt) {
         messageService.saveChatMessage(roomId, Long.valueOf(memberId), content);
         chatPublisher.publish(roomId, new ChatMessageResponse(roomId, memberId, content, sendAt));
+    }
+
+    @Transactional(readOnly = true)
+    public ChatRoom findChatRoom(Long roomId, Long memberId) {
+        ChatRoom room = chatService.findChatRoom(roomId);
+        Matching matching = room.getMatching();
+        participateService.validateMatchingParticipant(matching.getId(), memberId);
+
+        return room;
     }
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/common/path/chat/ChatPath.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/common/path/chat/ChatPath.java
@@ -1,0 +1,9 @@
+package com.mokakbob.common.path.chat;
+
+public class ChatPath {
+
+    public static final String ENTER = "/api/v1/chat/enter";
+    public static final String WS = "/ws-connect";
+    public static final String PUB = "/pub/chat";
+    public static final String SUB = "/sub/chat";
+}

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/chat/exception/ChatErrorCode.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/chat/exception/ChatErrorCode.java
@@ -3,6 +3,8 @@ package com.mokakbob.domain.chat.exception;
 import com.mokakbob.common.exception.DomainErrorCode;
 
 public enum ChatErrorCode implements DomainErrorCode {
+
+    NOT_FOUND_CHAT_ROOM(404, "C001", "채팅방을 찾을 수 없습니다.")
     ;
 
     private final int httpStatus;

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/chat/service/ChatService.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/chat/service/ChatService.java
@@ -1,6 +1,8 @@
 package com.mokakbob.domain.chat.service;
 
+import com.mokakbob.common.exception.DomainException;
 import com.mokakbob.domain.chat.domain.ChatRoom;
+import com.mokakbob.domain.chat.exception.ChatErrorCode;
 import com.mokakbob.domain.chat.repository.ChatRoomRepository;
 import com.mokakbob.domain.matching.domain.Matching;
 import lombok.RequiredArgsConstructor;
@@ -20,5 +22,11 @@ public class ChatService {
                 .build();
 
         return chatRoomRepository.save(chatRoom);
+    }
+
+    @Transactional(readOnly = true)
+    public ChatRoom findChatRoom(Long roomId) {
+        return chatRoomRepository.findById(roomId)
+                .orElseThrow(() -> new DomainException(ChatErrorCode.NOT_FOUND_CHAT_ROOM));
     }
 }

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/matching/exception/MatchingErrorCode.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/matching/exception/MatchingErrorCode.java
@@ -3,6 +3,9 @@ package com.mokakbob.domain.matching.exception;
 import com.mokakbob.common.exception.DomainErrorCode;
 
 public enum MatchingErrorCode implements DomainErrorCode {
+
+    // matchingParticipant
+    NOT_MATCHING_PARTICIPANT(401, "P001", "해당 매칭에 속하는 참여자가 아닙니다."),
     ;
 
     private final int httpStatus;

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/matching/repository/MatchingParticipantRepository.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/matching/repository/MatchingParticipantRepository.java
@@ -6,4 +6,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MatchingParticipantRepository extends JpaRepository<MatchingParticipant, Long> {
+
+    boolean existsByMatchingIdAndMemberIdAndIsAcceptedTrue(Long matchingId, Long memberId);
 }

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/matching/service/MatchingParticipateService.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/matching/service/MatchingParticipateService.java
@@ -1,0 +1,25 @@
+package com.mokakbob.domain.matching.service;
+
+import com.mokakbob.common.exception.DomainException;
+import com.mokakbob.domain.matching.exception.MatchingErrorCode;
+import com.mokakbob.domain.matching.repository.MatchingParticipantRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MatchingParticipateService {
+
+    private final MatchingParticipantRepository participantRepository;
+
+    @Transactional(readOnly = true)
+    public void validateMatchingParticipant(Long matchingId, Long memberId) {
+        boolean exists = participantRepository
+                .existsByMatchingIdAndMemberIdAndIsAcceptedTrue(matchingId, memberId);
+
+        if (!exists) {
+            throw new DomainException(MatchingErrorCode.NOT_MATCHING_PARTICIPANT);
+        }
+    }
+}


### PR DESCRIPTION
## 관련 이슈 번호
* #115 

## 작업 내용 (25.11.26)
* 채팅방 입장 API 구현
  * roomId 기반으로 ChatRoom 조회
  * ChatRoom → Matching 매핑된 matchingId 조회
  * 사용자가 해당 매칭의 참여자인지 검증 (isAccepted = true)

* Response에 채팅 연결에 필요한 정보 반환
  * WebSocket 연결 주소(wsUrl)
  * 메시지 발행 경로(pub)
  * 메시지 구독 경로(sub)