### PR TITLE
#117 [FEAT] 채팅방 목록 조회 api 구현

### DIFF
--- a/docker-compose-app.yml
+++ b/docker-compose-app.yml
@@ -253,6 +253,17 @@ services:
     networks:
       - monitoring-network
 
+  mysql:
+    image: mysql:8.0
+    container_name: mysql
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: 1234
+      MYSQL_DATABASE: mokakbob
+    ports:
+      - "3306:3306"
+    networks:
+      - monitoring-network
 
 networks:
   monitoring-network:

--- a/mokakbob-api/src/main/java/com/mokakbob/chat/controller/ChatController.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/controller/ChatController.java
@@ -32,4 +32,12 @@ public class ChatController {
                 ChatPath.SUB
         ));
     }
+
+    @GetMapping(ChatPath.ROOMS)
+    public ResponseEntity<Void> searchRooms(@MemberId Long memberId) {
+
+
+        return ResponseEntity.ok()
+                .build();
+    }
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/chat/controller/ChatController.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/controller/ChatController.java
@@ -2,10 +2,13 @@ package com.mokakbob.chat.controller;
 
 import com.mokakbob.chat.controller.request.ChatRoomEnterRequest;
 import com.mokakbob.chat.controller.response.ChatRoomEnterResponse;
+import com.mokakbob.chat.controller.response.ChatRoomResponse;
+import com.mokakbob.chat.controller.response.ChatRoomResponses;
 import com.mokakbob.chat.service.ChatApiService;
 import com.mokakbob.common.path.chat.ChatPath;
 import com.mokakbob.domain.chat.domain.ChatRoom;
 import com.mokakbob.global.resolver.annotation.MemberId;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -34,10 +37,9 @@ public class ChatController {
     }
 
     @GetMapping(ChatPath.ROOMS)
-    public ResponseEntity<Void> searchRooms(@MemberId Long memberId) {
+    public ResponseEntity<ChatRoomResponses> searchRooms(@MemberId Long memberId) {
+        List<ChatRoomResponse> chatRoomResponses = chatApiService.findChatRooms(memberId);
 
-
-        return ResponseEntity.ok()
-                .build();
+        return ResponseEntity.ok(new ChatRoomResponses(memberId, chatRoomResponses));
     }
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/chat/controller/response/ChatParticipantResponse.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/controller/response/ChatParticipantResponse.java
@@ -1,0 +1,22 @@
+package com.mokakbob.chat.controller.response;
+
+import com.mokakbob.domain.matching.domain.MatchingParticipant;
+import com.mokakbob.domain.member.domain.Member;
+
+public record ChatParticipantResponse(
+        Long memberId,
+        String nickname,
+        String profileImageUrl
+) {
+
+    public static ChatParticipantResponse of(
+            MatchingParticipant participant,
+            Member member
+    ) {
+        return new ChatParticipantResponse(
+                participant.getMemberId(),
+                member.getNickname(),
+                member.getProfileImage()
+        );
+    }
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/chat/controller/response/ChatRoomResponse.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/controller/response/ChatRoomResponse.java
@@ -1,0 +1,27 @@
+package com.mokakbob.chat.controller.response;
+
+import com.mokakbob.domain.chat.domain.ChatRoom;
+import com.mokakbob.domain.matching.domain.Matching;
+import com.mokakbob.domain.matching.domain.vo.MatchingStatus;
+import java.util.List;
+
+public record ChatRoomResponse(
+        Long roomId,
+        Long matchingId,
+        MatchingStatus matchingStatus,
+        List<ChatParticipantResponse> participants
+) {
+
+    public static ChatRoomResponse of(
+            ChatRoom room,
+            Matching matching,
+            List<ChatParticipantResponse> participants
+            ) {
+        return new ChatRoomResponse(
+                room.getId(),
+                matching.getId(),
+                matching.getStatus(),
+                participants
+        );
+    }
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/chat/controller/response/ChatRoomResponses.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/controller/response/ChatRoomResponses.java
@@ -1,0 +1,16 @@
+package com.mokakbob.chat.controller.response;
+
+import java.util.List;
+
+public record ChatRoomResponses(
+        Long memberId,
+        List<ChatRoomResponse> rooms
+) {
+
+    public static ChatRoomResponses of(
+            Long memberId,
+            List<ChatRoomResponse> rooms
+    ) {
+        return new ChatRoomResponses(memberId, rooms);
+    }
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/chat/service/ChatApiService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/service/ChatApiService.java
@@ -13,6 +13,8 @@ import com.mokakbob.domain.matching.service.MatchingParticipateService;
 import com.mokakbob.domain.member.domain.Member;
 import com.mokakbob.domain.member.service.MemberService;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -48,27 +50,57 @@ public class ChatApiService {
         List<Long> matchingIds = participants.stream()
                 .map(MatchingParticipant::getMatchingId)
                 .toList();
-        List<ChatRoom> rooms = chatService.findChatRooms(matchingIds);
+
+        if (matchingIds.isEmpty()) {
+            return List.of();
+        }
+
+        List<ChatRoom> rooms = chatService.findMatchingChatRooms(matchingIds);
+
+        List<MatchingParticipant> allParticipants = participateService.findMatchingParticipantByMatchingIds(
+                matchingIds);
+        Map<Long, List<MatchingParticipant>> groupedParticipants = loadParticipantsGroupedByMatchingId(allParticipants);
+        Map<Long, Member> members = loadMembersAsMap(allParticipants);
 
         return rooms.stream()
                 .map(room -> {
-                    Matching matching = room.getMatching();
-                    List<MatchingParticipant> matchingParticipants = participateService
-                            .findMatchingParticipantsByMatchingId(matching.getId());
+                    Long matchingId = room.getMatching().getId();
+
+                    List<MatchingParticipant> matchingParticipants = groupedParticipants.getOrDefault(matchingId,
+                            List.of());
+
                     List<ChatParticipantResponse> participantResponses =
                             matchingParticipants.stream()
-                                    .map(p -> {
-                                        Member member = memberService.findMember(p.getMemberId());
-                                        return ChatParticipantResponse.of(p, member);
-                                    })
+                                    .map(p -> ChatParticipantResponse.of(
+                                            p,
+                                            members.get(p.getMemberId())
+                                    ))
                                     .toList();
 
                     return ChatRoomResponse.of(
                             room,
-                            matching,
+                            room.getMatching(),
                             participantResponses
                     );
                 })
                 .toList();
+    }
+
+    private Map<Long, List<MatchingParticipant>> loadParticipantsGroupedByMatchingId(
+            List<MatchingParticipant> allParticipants) {
+        return allParticipants.stream()
+                .collect(Collectors.groupingBy(MatchingParticipant::getMatchingId));
+    }
+
+    private Map<Long, Member> loadMembersAsMap(List<MatchingParticipant> allParticipants) {
+        List<Long> memberIds = allParticipants.stream()
+                .map(MatchingParticipant::getMemberId)
+                .distinct()
+                .toList();
+
+        List<Member> members = memberService.findMembers(memberIds);
+
+        return members.stream()
+                .collect(Collectors.toMap(Member::getId, m -> m));
     }
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/chat/service/ChatApiService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/service/ChatApiService.java
@@ -1,12 +1,18 @@
 package com.mokakbob.chat.service;
 
+import com.mokakbob.chat.controller.response.ChatParticipantResponse;
+import com.mokakbob.chat.controller.response.ChatRoomResponse;
 import com.mokakbob.domain.chat.domain.ChatRoom;
 import com.mokakbob.domain.chat.pubsub.ChatPublisher;
 import com.mokakbob.domain.chat.pubsub.response.ChatMessageResponse;
 import com.mokakbob.domain.chat.service.ChatMessageService;
 import com.mokakbob.domain.chat.service.ChatService;
 import com.mokakbob.domain.matching.domain.Matching;
+import com.mokakbob.domain.matching.domain.MatchingParticipant;
 import com.mokakbob.domain.matching.service.MatchingParticipateService;
+import com.mokakbob.domain.member.domain.Member;
+import com.mokakbob.domain.member.service.MemberService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,6 +25,7 @@ public class ChatApiService {
     private final ChatMessageService messageService;
     private final ChatService chatService;
     private final MatchingParticipateService participateService;
+    private final MemberService memberService;
 
     @Transactional
     public void handleMessage(Long roomId, String memberId, String content, long sendAt) {
@@ -33,5 +40,35 @@ public class ChatApiService {
         participateService.validateMatchingParticipant(matching.getId(), memberId);
 
         return room;
+    }
+
+    @Transactional(readOnly = true)
+    public List<ChatRoomResponse> findChatRooms(Long memberId) {
+        List<MatchingParticipant> participants = participateService.findMatchingParticipantsByMemberId(memberId);
+        List<Long> matchingIds = participants.stream()
+                .map(MatchingParticipant::getMatchingId)
+                .toList();
+        List<ChatRoom> rooms = chatService.findChatRooms(matchingIds);
+
+        return rooms.stream()
+                .map(room -> {
+                    Matching matching = room.getMatching();
+                    List<MatchingParticipant> matchingParticipants = participateService
+                            .findMatchingParticipantsByMatchingId(matching.getId());
+                    List<ChatParticipantResponse> participantResponses =
+                            matchingParticipants.stream()
+                                    .map(p -> {
+                                        Member member = memberService.findMember(p.getMemberId());
+                                        return ChatParticipantResponse.of(p, member);
+                                    })
+                                    .toList();
+
+                    return ChatRoomResponse.of(
+                            room,
+                            matching,
+                            participantResponses
+                    );
+                })
+                .toList();
     }
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/common/path/chat/ChatPath.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/common/path/chat/ChatPath.java
@@ -2,6 +2,7 @@ package com.mokakbob.common.path.chat;
 
 public class ChatPath {
 
+    public static final String ROOMS = "/api/v1/chat/rooms";
     public static final String ENTER = "/api/v1/chat/enter";
     public static final String WS = "/ws-connect";
     public static final String PUB = "/pub/chat";

--- a/mokakbob-consumer/src/main/java/com/mokakbob/matching/consumer/MatchingParticipateConsumer.java
+++ b/mokakbob-consumer/src/main/java/com/mokakbob/matching/consumer/MatchingParticipateConsumer.java
@@ -1,7 +1,7 @@
 package com.mokakbob.matching.consumer;
 
 import com.mokakbob.domain.matching.event.MatchingParticipateEvent;
-import com.mokakbob.matching.service.MatchingParticipateService;
+import com.mokakbob.matching.service.MatchingParticipateApiService;
 import com.mokakbob.topic.KafkaTopic;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class MatchingParticipateConsumer {
 
-    private final MatchingParticipateService participateService;
+    private final MatchingParticipateApiService participateService;
 
     @KafkaListener(
             topics = KafkaTopic.MATCHING_PARTICIPATE,

--- a/mokakbob-consumer/src/main/java/com/mokakbob/matching/service/MatchingParticipateApiService.java
+++ b/mokakbob-consumer/src/main/java/com/mokakbob/matching/service/MatchingParticipateApiService.java
@@ -36,7 +36,7 @@ import org.springframework.stereotype.Service;
  */
 @Service
 @RequiredArgsConstructor
-public class MatchingParticipateService {
+public class MatchingParticipateApiService {
 
     private static final double RADIUS_METERS = 1500.0;
     private static final int LIMIT_LOCK_CATCH_TIME = 3;

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/chat/repository/ChatRoomRepository.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/chat/repository/ChatRoomRepository.java
@@ -3,10 +3,18 @@ package com.mokakbob.domain.chat.repository;
 import com.mokakbob.domain.chat.domain.ChatRoom;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
-    List<ChatRoom> findAllByMatchingIdIn(List<Long> matchingIds);
+    @Query("""
+                select cr
+                from ChatRoom cr
+                join fetch cr.matching m
+                where m.id in :matchingIds
+            """)
+    List<ChatRoom> findAllWithMatchingByMatchingIdIn(@Param("matchingIds") List<Long> matchingIds);
 }

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/chat/repository/ChatRoomRepository.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/chat/repository/ChatRoomRepository.java
@@ -1,9 +1,12 @@
 package com.mokakbob.domain.chat.repository;
 
 import com.mokakbob.domain.chat.domain.ChatRoom;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+
+    List<ChatRoom> findAllByMatchingIdIn(List<Long> matchingIds);
 }

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/chat/service/ChatService.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/chat/service/ChatService.java
@@ -32,7 +32,7 @@ public class ChatService {
     }
 
     @Transactional(readOnly = true)
-    public List<ChatRoom> findChatRooms(List<Long> matchingIds) {
-        return chatRoomRepository.findAllByMatchingIdIn(matchingIds);
+    public List<ChatRoom> findMatchingChatRooms(List<Long> matchingIds) {
+        return chatRoomRepository.findAllWithMatchingByMatchingIdIn(matchingIds);
     }
 }

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/chat/service/ChatService.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/chat/service/ChatService.java
@@ -5,6 +5,7 @@ import com.mokakbob.domain.chat.domain.ChatRoom;
 import com.mokakbob.domain.chat.exception.ChatErrorCode;
 import com.mokakbob.domain.chat.repository.ChatRoomRepository;
 import com.mokakbob.domain.matching.domain.Matching;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,5 +29,10 @@ public class ChatService {
     public ChatRoom findChatRoom(Long roomId) {
         return chatRoomRepository.findById(roomId)
                 .orElseThrow(() -> new DomainException(ChatErrorCode.NOT_FOUND_CHAT_ROOM));
+    }
+
+    @Transactional(readOnly = true)
+    public List<ChatRoom> findChatRooms(List<Long> matchingIds) {
+        return chatRoomRepository.findAllByMatchingIdIn(matchingIds);
     }
 }

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/matching/repository/MatchingParticipantRepository.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/matching/repository/MatchingParticipantRepository.java
@@ -10,5 +10,5 @@ public interface MatchingParticipantRepository extends JpaRepository<MatchingPar
 
     boolean existsByMatchingIdAndMemberIdAndIsAcceptedTrue(Long matchingId, Long memberId);
     List<MatchingParticipant> findByMemberId(Long memberId);
-    List<MatchingParticipant> findByMatchingId(Long matchingId);
+    List<MatchingParticipant> findByMatchingIdIn(List<Long> matchingIds);
 }

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/matching/repository/MatchingParticipantRepository.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/matching/repository/MatchingParticipantRepository.java
@@ -1,6 +1,7 @@
 package com.mokakbob.domain.matching.repository;
 
 import com.mokakbob.domain.matching.domain.MatchingParticipant;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -8,4 +9,6 @@ import org.springframework.stereotype.Repository;
 public interface MatchingParticipantRepository extends JpaRepository<MatchingParticipant, Long> {
 
     boolean existsByMatchingIdAndMemberIdAndIsAcceptedTrue(Long matchingId, Long memberId);
+    List<MatchingParticipant> findByMemberId(Long memberId);
+    List<MatchingParticipant> findByMatchingId(Long matchingId);
 }

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/matching/service/MatchingParticipateService.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/matching/service/MatchingParticipateService.java
@@ -1,8 +1,10 @@
 package com.mokakbob.domain.matching.service;
 
 import com.mokakbob.common.exception.DomainException;
+import com.mokakbob.domain.matching.domain.MatchingParticipant;
 import com.mokakbob.domain.matching.exception.MatchingErrorCode;
 import com.mokakbob.domain.matching.repository.MatchingParticipantRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,5 +23,15 @@ public class MatchingParticipateService {
         if (!exists) {
             throw new DomainException(MatchingErrorCode.NOT_MATCHING_PARTICIPANT);
         }
+    }
+
+    @Transactional(readOnly = true)
+    public List<MatchingParticipant> findMatchingParticipantsByMemberId(Long memberId) {
+        return participantRepository.findByMemberId(memberId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<MatchingParticipant> findMatchingParticipantsByMatchingId(Long matchingId) {
+        return participantRepository.findByMatchingId(matchingId);
     }
 }

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/matching/service/MatchingParticipateService.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/matching/service/MatchingParticipateService.java
@@ -31,7 +31,7 @@ public class MatchingParticipateService {
     }
 
     @Transactional(readOnly = true)
-    public List<MatchingParticipant> findMatchingParticipantsByMatchingId(Long matchingId) {
-        return participantRepository.findByMatchingId(matchingId);
+    public List<MatchingParticipant> findMatchingParticipantByMatchingIds(List<Long> matchingId) {
+        return participantRepository.findByMatchingIdIn(matchingId);
     }
 }

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/member/repository/MemberRepository.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/member/repository/MemberRepository.java
@@ -3,6 +3,7 @@ package com.mokakbob.domain.member.repository;
 import com.mokakbob.domain.member.domain.Member;
 import jakarta.persistence.LockModeType;
 import jakarta.persistence.QueryHint;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
@@ -25,4 +26,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     @Query("select m from Member m where m.id = :id")
     @QueryHints(@QueryHint(name = "jakarta.persistence.lock.timeout", value = "5000"))
     Optional<Member> findByIdForUpdate(Long id);
+
+    List<Member> findByIdIn(List<Long> ids);
 }

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/member/service/MemberService.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/member/service/MemberService.java
@@ -5,6 +5,7 @@ import com.mokakbob.domain.member.domain.Member;
 import com.mokakbob.domain.member.domain.vo.MemberPreference;
 import com.mokakbob.domain.member.exception.MemberErrorCode;
 import com.mokakbob.domain.member.repository.MemberRepository;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -59,6 +60,11 @@ public class MemberService {
     public Member findMemberForUpdate(Long memberId) {
         return memberRepository.findByIdForUpdate(memberId)
                 .orElseThrow(() -> new DomainException(MemberErrorCode.NOT_FOUND_MEMBER));
+    }
+
+    @Transactional
+    public List<Member> findMembers(List<Long> memberIds) {
+        return memberRepository.findByIdIn(memberIds);
     }
 
     private void validateDuplicateEmail(String email) {


### PR DESCRIPTION
## 관련 이슈 번호
* #117 closed

## 작업 내용 (25.11.28)

### 채팅방 목록 조회 API 구현
* 사용자가 참여 중인 매칭 목록을 기준으로 채팅방 목록을 조회하는 API 구현
* `ChatRoomResponse`, `ChatRoomResponses`, `ChatParticipantResponse` DTO 설계
* ChatRoom > Matching > Participants > Member 까지 필요한 연관 데이터를 담아 응답하도록 구조화
* 페이징 고려하여 `roomId` 기반의 조회 방식으로 설계

### 기존 구현에서 발생한 `N + 1` 문제 분석
기존 조회 로직에서 다음과 같은 세 가지 `N + 1` 문제가 발생
 
1. ChatRoom > Matching (LAZY 조회): 채팅방 목록 조회 후 `room.getMatching()` 호출 시 `matching` 조회 쿼리가 N번 반복됨.
2. Matching > MatchingParticipant: 매칭 아이디별로 참여자 목록 조회 시 쿼리가 N번 반복됨
3. MatchingParticipant > Member: 각 참여자마다 회원 정보를 개별 조회하여 P번의 쿼리가 추가 발생함

(데이터 증가에 따라 쿼리 수가 증가하는 구조)

### `N + 1` 해결: fetch join + 벌크 조회 + in-memory 적용

1. ChatRoom > Matching 은 fetch join으로 해결
  * Matching을 즉시 로딩하여 LAZY N + 1 제거
  * 따라서, 이후 `room.getMatching()` 호출 시 추가 쿼리 없음

2. MatchingParticipant 벌크 조회
  * IN 조건으로 한 번에 매칭별 참여자 조회
  * 기존 N번 쿼리를 1번으로 축소

3. Member 벌크 조회 후 Map 변환
  * 참여자들의 `memberId`를 한 번에 모아 IN 조회
  * 기존 P개의 개별 조회를 1번 쿼리로 축소

4. 최종적으로 in-memory 매핑

>따라서, 데이터 수와 무관하게 항상 4개의 쿼리로 고정됨.


### fetch join + 벌크 조회 + in-memory 방식 선정 이유
* 예상 사용자 수(약 500명 수준)에서 가장 합리적인 성능 구조
  * 서비스의 예상 사용자는 약 500명 수준이며, 채팅 기능도 이 규모를 기준으로 설계되어 있음.
  * 따라서 매칭별 참여자, 참여 회원을 벌크 조회(IN 조회)로 한 번에 가져오는 방식이 성능적으로 전혀 부담X.


* fetch join 만 사용하지 않은 이유
  * Matching > MatchingParticipant 관계가 OneToMany 
  * 따라서, 여기에 fetch join을 사용하면 row 수가 자식 수만큼 폭발(이후 distinct 발생)
  * 결국 페이징 확장성 부족과 성능 저하로 fetch join 만 사용하지 않음

* DTO Projection(QueryDSL) 사용하지 않은 이유
  * response 구조가 컬렉션이 중첩된 형태
    ~~~
    ChatRoom > Participants > Member 정보
    ~~~
  * 따라서, 단일 DTO Projection으로 표현하려면 쿼리 구조가 복잡 + 유지보수성이 너무 떨어진다고 생각했음