### PR TITLE
#119 [FEAT] 채팅방 목록 offset 기반 페이징 적용

### DIFF
--- a/mokakbob-api/src/main/java/com/mokakbob/chat/controller/ChatController.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/controller/ChatController.java
@@ -2,17 +2,16 @@ package com.mokakbob.chat.controller;
 
 import com.mokakbob.chat.controller.request.ChatRoomEnterRequest;
 import com.mokakbob.chat.controller.response.ChatRoomEnterResponse;
-import com.mokakbob.chat.controller.response.ChatRoomResponse;
 import com.mokakbob.chat.controller.response.ChatRoomResponses;
 import com.mokakbob.chat.service.ChatApiService;
 import com.mokakbob.common.path.chat.ChatPath;
 import com.mokakbob.domain.chat.domain.ChatRoom;
 import com.mokakbob.global.resolver.annotation.MemberId;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -37,9 +36,11 @@ public class ChatController {
     }
 
     @GetMapping(ChatPath.ROOMS)
-    public ResponseEntity<ChatRoomResponses> searchRooms(@MemberId Long memberId) {
-        List<ChatRoomResponse> chatRoomResponses = chatApiService.findChatRooms(memberId);
-
-        return ResponseEntity.ok(new ChatRoomResponses(memberId, chatRoomResponses));
+    public ResponseEntity<ChatRoomResponses> searchRooms(
+            @MemberId Long memberId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        return ResponseEntity.ok(chatApiService.findChatRooms(memberId, page, size));
     }
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/chat/controller/response/ChatRoomResponses.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/controller/response/ChatRoomResponses.java
@@ -1,7 +1,7 @@
 package com.mokakbob.chat.controller.response;
 
 import java.util.List;
-import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public record ChatRoomResponses(
         Long memberId,
@@ -12,18 +12,39 @@ public record ChatRoomResponses(
         int totalPages,
         boolean last
 ) {
+
+    private static final Long EMPTY_TOTAL_ELEMENTS = 0L;
+    private static final int EMPTY_TOTAL_PAGE = 0;
+
     public static ChatRoomResponses of(
             Long memberId,
-            Page<ChatRoomResponse> pageResult
+            List<ChatRoomResponse> rooms,
+            int page,
+            int size,
+            long totalElements,
+            int totalPages,
+            boolean last
     ) {
         return new ChatRoomResponses(
                 memberId,
-                pageResult.getContent(),
-                pageResult.getNumber(),
-                pageResult.getSize(),
-                pageResult.getTotalElements(),
-                pageResult.getTotalPages(),
-                pageResult.isLast()
+                rooms,
+                page,
+                size,
+                totalElements,
+                totalPages,
+                last
+        );
+    }
+
+    public static ChatRoomResponses empty(Long memberId, Pageable pageable) {
+        return new ChatRoomResponses(
+                memberId,
+                List.of(),
+                pageable.getPageNumber(),
+                pageable.getPageSize(),
+                EMPTY_TOTAL_ELEMENTS,
+                EMPTY_TOTAL_PAGE,
+                true
         );
     }
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/chat/controller/response/ChatRoomResponses.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/controller/response/ChatRoomResponses.java
@@ -1,16 +1,29 @@
 package com.mokakbob.chat.controller.response;
 
 import java.util.List;
+import org.springframework.data.domain.Page;
 
 public record ChatRoomResponses(
         Long memberId,
-        List<ChatRoomResponse> rooms
+        List<ChatRoomResponse> rooms,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages,
+        boolean last
 ) {
-
     public static ChatRoomResponses of(
             Long memberId,
-            List<ChatRoomResponse> rooms
+            Page<ChatRoomResponse> pageResult
     ) {
-        return new ChatRoomResponses(memberId, rooms);
+        return new ChatRoomResponses(
+                memberId,
+                pageResult.getContent(),
+                pageResult.getNumber(),
+                pageResult.getSize(),
+                pageResult.getTotalElements(),
+                pageResult.getTotalPages(),
+                pageResult.isLast()
+        );
     }
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/chat/service/ChatApiService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/service/ChatApiService.java
@@ -1,7 +1,9 @@
 package com.mokakbob.chat.service;
 
-import com.mokakbob.chat.controller.response.ChatParticipantResponse;
 import com.mokakbob.chat.controller.response.ChatRoomResponse;
+import com.mokakbob.chat.controller.response.ChatRoomResponses;
+import com.mokakbob.chat.service.support.ParticipantContext;
+import com.mokakbob.chat.util.ChatRoomMapper;
 import com.mokakbob.domain.chat.domain.ChatRoom;
 import com.mokakbob.domain.chat.pubsub.ChatPublisher;
 import com.mokakbob.domain.chat.pubsub.response.ChatMessageResponse;
@@ -16,12 +18,18 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class ChatApiService {
+
+    private static final String PAGING_SORT_DELIMITER = "id";
 
     private final ChatPublisher chatPublisher;
     private final ChatMessageService messageService;
@@ -44,52 +52,62 @@ public class ChatApiService {
         return room;
     }
 
+    /**
+     * 사용자가 참여한 채팅방 목록을 Offset 기반으로 페이징하여 조회한다.
+     *
+     * <p>조회 기준은 {@link MatchingParticipant} 엔티티이며,
+     * MatchingParticipant → Matching → ChatRoom 이 1:1 대응되는 구조를 활용한다.</p>
+     *
+     * <p>페이징된 MatchingParticipant 목록에서 matchingId를 추출하여
+     * 해당 매칭의 채팅방(ChatRoom)을 조회하고, 이후 각 매칭에 참여한 사용자 목록과 회원(Member) 정보를 Bulk 조회 후 In-memory 매핑하여 응답을 구성한다.</p>
+     *
+     * @param memberId 조회할 사용자의 ID
+     * @param page     페이지 번호(0-based)
+     * @param size     페이지 크기
+     * @return 페이징된 채팅방 응답 목록
+     */
     @Transactional(readOnly = true)
-    public List<ChatRoomResponse> findChatRooms(Long memberId) {
-        List<MatchingParticipant> participants = participateService.findMatchingParticipantsByMemberId(memberId);
-        List<Long> matchingIds = participants.stream()
-                .map(MatchingParticipant::getMatchingId)
-                .toList();
+    public ChatRoomResponses findChatRooms(Long memberId, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by(PAGING_SORT_DELIMITER).descending());
 
-        if (matchingIds.isEmpty()) {
-            return List.of();
+        Page<MatchingParticipant> participantPage =
+                participateService.findMatchingParticipantsByMemberId(memberId, pageable);
+
+        if (participantPage.isEmpty()) {
+            return ChatRoomResponses.empty(memberId, pageable);
         }
 
+        List<Long> matchingIds = extractMatchingIds(participantPage.getContent());
         List<ChatRoom> rooms = chatService.findMatchingChatRooms(matchingIds);
+        ParticipantContext context = loadParticipantContext(matchingIds);
+        List<ChatRoomResponse> responses = mapToChatRoomResponses(rooms, context);
 
-        List<MatchingParticipant> allParticipants = participateService.findMatchingParticipantByMatchingIds(
-                matchingIds);
-        Map<Long, List<MatchingParticipant>> groupedParticipants = loadParticipantsGroupedByMatchingId(allParticipants);
-        Map<Long, Member> members = loadMembersAsMap(allParticipants);
+        return ChatRoomResponses.of(
+                memberId,
+                responses,
+                participantPage.getNumber(),
+                participantPage.getSize(),
+                participantPage.getTotalElements(),
+                participantPage.getTotalPages(),
+                participantPage.isLast()
+        );
+    }
 
-        return rooms.stream()
-                .map(room -> {
-                    Long matchingId = room.getMatching().getId();
-
-                    List<MatchingParticipant> matchingParticipants = groupedParticipants.getOrDefault(matchingId,
-                            List.of());
-
-                    List<ChatParticipantResponse> participantResponses =
-                            matchingParticipants.stream()
-                                    .map(p -> ChatParticipantResponse.of(
-                                            p,
-                                            members.get(p.getMemberId())
-                                    ))
-                                    .toList();
-
-                    return ChatRoomResponse.of(
-                            room,
-                            room.getMatching(),
-                            participantResponses
-                    );
-                })
+    private List<Long> extractMatchingIds(List<MatchingParticipant> participants) {
+        return participants.stream()
+                .map(MatchingParticipant::getMatchingId)
+                .distinct()
                 .toList();
     }
 
-    private Map<Long, List<MatchingParticipant>> loadParticipantsGroupedByMatchingId(
-            List<MatchingParticipant> allParticipants) {
-        return allParticipants.stream()
+    private ParticipantContext loadParticipantContext(List<Long> matchingIds) {
+        List<MatchingParticipant> participants = participateService.findMatchingParticipantByMatchingIds(matchingIds);
+
+        Map<Long, List<MatchingParticipant>> participantsByMatchingId = participants.stream()
                 .collect(Collectors.groupingBy(MatchingParticipant::getMatchingId));
+        Map<Long, Member> memberMap = loadMembersAsMap(participants);
+
+        return new ParticipantContext(participantsByMatchingId, memberMap);
     }
 
     private Map<Long, Member> loadMembersAsMap(List<MatchingParticipant> allParticipants) {
@@ -97,10 +115,25 @@ public class ChatApiService {
                 .map(MatchingParticipant::getMemberId)
                 .distinct()
                 .toList();
-
         List<Member> members = memberService.findMembers(memberIds);
 
         return members.stream()
                 .collect(Collectors.toMap(Member::getId, m -> m));
+    }
+
+    private List<ChatRoomResponse> mapToChatRoomResponses(List<ChatRoom> rooms, ParticipantContext context) {
+        return rooms.stream()
+                .map(room -> {
+                    Long matchingId = room.getMatching().getId();
+                    List<MatchingParticipant> participants = context.participantsByMatchingId()
+                            .getOrDefault(matchingId, List.of());
+
+                    return ChatRoomMapper.toChatRoomResponse(
+                            room,
+                            participants,
+                            context.memberMap()
+                    );
+                })
+                .toList();
     }
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/chat/service/support/ParticipantContext.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/service/support/ParticipantContext.java
@@ -1,0 +1,18 @@
+package com.mokakbob.chat.service.support;
+
+import com.mokakbob.domain.matching.domain.MatchingParticipant;
+import com.mokakbob.domain.member.domain.Member;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 특정 매칭 ID들을 기준으로 조회된
+ * - 매칭 참여자 목록
+ * - 회원 정보
+ * 두 가지 데이터를 서비스 계층에서 효율적으로 접근하기 위한 컨텍스트 객체.
+ */
+public record ParticipantContext(
+        Map<Long, List<MatchingParticipant>> participantsByMatchingId,
+        Map<Long, Member> memberMap
+) {
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/chat/util/ChatRoomMapper.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/util/ChatRoomMapper.java
@@ -1,0 +1,51 @@
+package com.mokakbob.chat.util;
+
+import com.mokakbob.chat.controller.response.ChatParticipantResponse;
+import com.mokakbob.chat.controller.response.ChatRoomResponse;
+import com.mokakbob.domain.chat.domain.ChatRoom;
+import com.mokakbob.domain.matching.domain.Matching;
+import com.mokakbob.domain.matching.domain.MatchingParticipant;
+import com.mokakbob.domain.member.domain.Member;
+import java.util.List;
+import java.util.Map;
+
+public final class ChatRoomMapper {
+
+    private ChatRoomMapper() {
+    }
+
+    /**
+     * ChatRoom -> ChatRoomResponse 변환
+     */
+    public static ChatRoomResponse toChatRoomResponse(
+            ChatRoom room,
+            List<MatchingParticipant> participants,
+            Map<Long, Member> memberMap
+    ) {
+        Matching matching = room.getMatching();
+
+        List<ChatParticipantResponse> participantResponses =
+                toChatParticipantResponses(participants, memberMap);
+
+        return ChatRoomResponse.of(
+                room,
+                matching,
+                participantResponses
+        );
+    }
+
+    /**
+     * MatchingParticipant + Member -> ChatParticipantResponse 변환
+     */
+    public static List<ChatParticipantResponse> toChatParticipantResponses(
+            List<MatchingParticipant> participants,
+            Map<Long, Member> members
+    ) {
+        return participants.stream()
+                .map(p -> ChatParticipantResponse.of(
+                        p,
+                        members.get(p.getMemberId())
+                ))
+                .toList();
+    }
+}

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/matching/repository/MatchingParticipantRepository.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/matching/repository/MatchingParticipantRepository.java
@@ -2,6 +2,8 @@ package com.mokakbob.domain.matching.repository;
 
 import com.mokakbob.domain.matching.domain.MatchingParticipant;
 import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,6 +11,8 @@ import org.springframework.stereotype.Repository;
 public interface MatchingParticipantRepository extends JpaRepository<MatchingParticipant, Long> {
 
     boolean existsByMatchingIdAndMemberIdAndIsAcceptedTrue(Long matchingId, Long memberId);
-    List<MatchingParticipant> findByMemberId(Long memberId);
+
+    Page<MatchingParticipant> findByMemberId(Long memberId, Pageable pageable);
+
     List<MatchingParticipant> findByMatchingIdIn(List<Long> matchingIds);
 }

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/matching/service/MatchingParticipateService.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/matching/service/MatchingParticipateService.java
@@ -6,6 +6,8 @@ import com.mokakbob.domain.matching.exception.MatchingErrorCode;
 import com.mokakbob.domain.matching.repository.MatchingParticipantRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,8 +28,8 @@ public class MatchingParticipateService {
     }
 
     @Transactional(readOnly = true)
-    public List<MatchingParticipant> findMatchingParticipantsByMemberId(Long memberId) {
-        return participantRepository.findByMemberId(memberId);
+    public Page<MatchingParticipant> findMatchingParticipantsByMemberId(Long memberId, Pageable pageable) {
+        return participantRepository.findByMemberId(memberId, pageable);
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## 관련 이슈 번호
* #119 closed

## 작업 내용 (25.11.28)
* 기존에는 사용자가 참여한 모든 매칭을 가져온 뒤 Bulk 조회 및 In-Memory 조합을 수행하는 방식이었으나, 참여 이력이 많아질 경우 성능 이슈가 발생할 수 있어 페이징 기준을 명확히 정의하고 전체 구조를 재정비 진행.

### `MatchingParticipant `기반 Offset Pagination 구현
* MatchingParticipant > Matching > ChatRoom 구조가 1:1 관계이기 때문에, `MatchingParticipant`를 페이징 기준 엔티티로 선정
* `PageRequest(page, size)` 기반 Offset 페이징 적용
* Service 단에서 page/size 값을 받아 pageable 생성 및 적용