### PR TITLE
#121 [FEAT] 채팅 히스토리 조회 API 구현

### DIFF
--- a/mokakbob-api/src/main/java/com/mokakbob/chat/controller/ChatController.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/controller/ChatController.java
@@ -61,6 +61,6 @@ public class ChatController {
     ) {
         List<ChatMessage> messages = chatApiService.findChatMessages(memberId, roomId, cursor, size);
 
-        return ResponseEntity.ok(ChatMessagesResponse.of(memberId, roomId, messages));
+        return ResponseEntity.ok(ChatMessagesResponse.of(memberId, roomId, messages, size));
     }
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/chat/controller/ChatController.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/controller/ChatController.java
@@ -9,10 +9,8 @@ import com.mokakbob.common.path.chat.ChatPath;
 import com.mokakbob.domain.chat.domain.ChatMessage;
 import com.mokakbob.domain.chat.domain.ChatRoom;
 import com.mokakbob.global.resolver.annotation.MemberId;
-import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -54,9 +52,7 @@ public class ChatController {
     public ResponseEntity<ChatMessagesResponse> getMessages(
             @PathVariable Long roomId,
             @MemberId Long memberId,
-            @RequestParam(required = false)
-            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-            LocalDateTime cursor,
+            @RequestParam(required = false) String cursor,
             @RequestParam(required = false) Integer size
     ) {
         List<ChatMessage> messages = chatApiService.findChatMessages(memberId, roomId, cursor, size);

--- a/mokakbob-api/src/main/java/com/mokakbob/chat/controller/ChatController.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/controller/ChatController.java
@@ -1,15 +1,21 @@
 package com.mokakbob.chat.controller;
 
 import com.mokakbob.chat.controller.request.ChatRoomEnterRequest;
+import com.mokakbob.chat.controller.response.ChatMessagesResponse;
 import com.mokakbob.chat.controller.response.ChatRoomEnterResponse;
 import com.mokakbob.chat.controller.response.ChatRoomResponses;
 import com.mokakbob.chat.service.ChatApiService;
 import com.mokakbob.common.path.chat.ChatPath;
+import com.mokakbob.domain.chat.domain.ChatMessage;
 import com.mokakbob.domain.chat.domain.ChatRoom;
 import com.mokakbob.global.resolver.annotation.MemberId;
+import java.time.LocalDateTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -42,5 +48,19 @@ public class ChatController {
             @RequestParam(defaultValue = "20") int size
     ) {
         return ResponseEntity.ok(chatApiService.findChatRooms(memberId, page, size));
+    }
+
+    @GetMapping(ChatPath.MESSAGES)
+    public ResponseEntity<ChatMessagesResponse> getMessages(
+            @PathVariable Long roomId,
+            @MemberId Long memberId,
+            @RequestParam(required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+            LocalDateTime cursor,
+            @RequestParam(required = false) Integer size
+    ) {
+        List<ChatMessage> messages = chatApiService.findChatMessages(memberId, roomId, cursor, size);
+
+        return ResponseEntity.ok(ChatMessagesResponse.of(memberId, roomId, messages));
     }
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/chat/controller/response/ChatMessageHistoryResponse.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/controller/response/ChatMessageHistoryResponse.java
@@ -1,0 +1,21 @@
+package com.mokakbob.chat.controller.response;
+
+import com.mokakbob.domain.chat.domain.ChatMessage;
+import java.time.LocalDateTime;
+
+public record ChatMessageHistoryResponse(
+        Long id,
+        Long senderId,
+        String content,
+        LocalDateTime createdAt
+) {
+
+    public static ChatMessageHistoryResponse from(ChatMessage message) {
+        return new ChatMessageHistoryResponse(
+                message.getId(),
+                message.getSenderId(),
+                message.getMessage(),
+                message.getCreatedAt()
+        );
+    }
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/chat/controller/response/ChatMessagesResponse.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/controller/response/ChatMessagesResponse.java
@@ -1,7 +1,6 @@
 package com.mokakbob.chat.controller.response;
 
 import com.mokakbob.domain.chat.domain.ChatMessage;
-import java.time.LocalDateTime;
 import java.util.List;
 
 public record ChatMessagesResponse(
@@ -12,24 +11,32 @@ public record ChatMessagesResponse(
         boolean hasNext
 ) {
 
-    private static final int CHAT_LAST_MESSAGE_MAKER = 1;
+    private static final int LAST_MESSAGE_DELIMITER = 1;
+    private static final int START_MESSAGE_DELIMITER = 0;
 
     public static ChatMessagesResponse of(
             Long memberId,
             Long chatRoomId,
-            List<ChatMessage> messages
+            List<ChatMessage> messages,
+            int pageSize
     ) {
-        List<ChatMessageHistoryResponse> messageResponses = messages.stream()
+        boolean hasNext = false;
+        List<ChatMessage> slice = messages;
+
+        if (messages.size() > pageSize) {
+            hasNext = true;
+            slice = messages.subList(START_MESSAGE_DELIMITER, pageSize);
+        }
+
+        List<ChatMessageHistoryResponse> messageResponses = slice.stream()
                 .map(ChatMessageHistoryResponse::from)
                 .toList();
         String nextCursor = null;
-        boolean hasNext = false;
 
-        if (!messages.isEmpty()) {
-            ChatMessage oldest = messages.get(messages.size() - CHAT_LAST_MESSAGE_MAKER);
-            LocalDateTime cursor = oldest.getCreatedAt();
-            nextCursor = cursor.toString();
-            hasNext = true;
+        if (!slice.isEmpty()) {
+            ChatMessage oldest = slice.get(slice.size() - LAST_MESSAGE_DELIMITER);
+            nextCursor = oldest.getCreatedAt()
+                    .toString();
         }
 
         return new ChatMessagesResponse(

--- a/mokakbob-api/src/main/java/com/mokakbob/chat/controller/response/ChatMessagesResponse.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/controller/response/ChatMessagesResponse.java
@@ -13,6 +13,7 @@ public record ChatMessagesResponse(
 
     private static final int LAST_MESSAGE_DELIMITER = 1;
     private static final int START_MESSAGE_DELIMITER = 0;
+    private static final String CURSOR_DELIMITER = "_";
 
     public static ChatMessagesResponse of(
             Long memberId,
@@ -48,9 +49,9 @@ public record ChatMessagesResponse(
     }
 
     /**
-     * 복합 커서 인코딩: createdAt|id
+     * 복합 커서 인코딩: createdAt_id
      */
     private static String encodeCursor(ChatMessage message) {
-        return message.getCreatedAt().toString() + "|" + message.getId();
+        return message.getCreatedAt().toString() + CURSOR_DELIMITER + message.getId();
     }
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/chat/controller/response/ChatMessagesResponse.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/controller/response/ChatMessagesResponse.java
@@ -1,0 +1,43 @@
+package com.mokakbob.chat.controller.response;
+
+import com.mokakbob.domain.chat.domain.ChatMessage;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record ChatMessagesResponse(
+        Long memberId,
+        Long chatRoomId,
+        List<ChatMessageHistoryResponse> messages,
+        String nextCursor,
+        boolean hasNext
+) {
+
+    private static final int CHAT_LAST_MESSAGE_MAKER = 1;
+
+    public static ChatMessagesResponse of(
+            Long memberId,
+            Long chatRoomId,
+            List<ChatMessage> messages
+    ) {
+        List<ChatMessageHistoryResponse> messageResponses = messages.stream()
+                .map(ChatMessageHistoryResponse::from)
+                .toList();
+        String nextCursor = null;
+        boolean hasNext = false;
+
+        if (!messages.isEmpty()) {
+            ChatMessage oldest = messages.get(messages.size() - CHAT_LAST_MESSAGE_MAKER);
+            LocalDateTime cursor = oldest.getCreatedAt();
+            nextCursor = cursor.toString();
+            hasNext = true;
+        }
+
+        return new ChatMessagesResponse(
+                memberId,
+                chatRoomId,
+                messageResponses,
+                nextCursor,
+                hasNext
+        );
+    }
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/chat/controller/response/ChatMessagesResponse.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/controller/response/ChatMessagesResponse.java
@@ -35,8 +35,7 @@ public record ChatMessagesResponse(
 
         if (!slice.isEmpty()) {
             ChatMessage oldest = slice.get(slice.size() - LAST_MESSAGE_DELIMITER);
-            nextCursor = oldest.getCreatedAt()
-                    .toString();
+            nextCursor = encodeCursor(oldest);
         }
 
         return new ChatMessagesResponse(
@@ -46,5 +45,12 @@ public record ChatMessagesResponse(
                 nextCursor,
                 hasNext
         );
+    }
+
+    /**
+     * 복합 커서 인코딩: createdAt|id
+     */
+    private static String encodeCursor(ChatMessage message) {
+        return message.getCreatedAt().toString() + "|" + message.getId();
     }
 }

--- a/mokakbob-api/src/main/java/com/mokakbob/chat/exception/ChatErrorCode.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/exception/ChatErrorCode.java
@@ -4,9 +4,13 @@ import com.mokakbob.common.exception.exceptions.ApiErrorCode;
 
 public enum ChatErrorCode implements ApiErrorCode {
 
+    // STOMP
     STOMP_JWT_MISSING(401, "CHAT_001", "Authorization 헤더가 없습니다."),
     STOMP_JWT_INVALID(401, "CHAT_002", "유효하지 않은 JWT 토큰입니다."),
-    STOMP_JWT_EXPIRED(401, "CHAT_003", "JWT 토큰이 만료되었습니다.")
+    STOMP_JWT_EXPIRED(401, "CHAT_003", "JWT 토큰이 만료되었습니다."),
+
+    // MESSAGE
+    NOT_SUPPORT_CURSOR_FORMAT(401, "MESSAGE_001", "잘못된 커서 요청입니다."),
     ;
 
     private final int httpStatus;

--- a/mokakbob-api/src/main/java/com/mokakbob/chat/service/ChatApiService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/service/ChatApiService.java
@@ -1,8 +1,12 @@
 package com.mokakbob.chat.service;
 
+import static com.mokakbob.chat.util.ChatMessageMapper.toChatMessages;
+
+import com.mokakbob.cache.ChatMessageStore;
 import com.mokakbob.chat.controller.response.ChatRoomResponse;
 import com.mokakbob.chat.controller.response.ChatRoomResponses;
 import com.mokakbob.chat.exception.ChatErrorCode;
+import com.mokakbob.domain.chat.cache.CachedChatMessage;
 import com.mokakbob.domain.chat.cursor.CursorToken;
 import com.mokakbob.chat.service.support.ParticipantContext;
 import com.mokakbob.chat.util.ChatRoomMapper;
@@ -45,6 +49,7 @@ public class ChatApiService {
     private final ChatService chatService;
     private final MatchingParticipateService participateService;
     private final MemberService memberService;
+    private final ChatMessageStore chatMessageStore;
 
     @Transactional
     public void handleMessage(Long roomId, String memberId, String content, long sendAt) {
@@ -68,6 +73,15 @@ public class ChatApiService {
         int pageSize = normalizeSize(size);
         int sizePlusOne = pageSize + HAS_NEXT_DELIMITER;
 
+        // redis 조회
+        List<CachedChatMessage> cachedMessages =
+                chatMessageStore.loadMessages(room.getId(), rawCursor, sizePlusOne);
+
+        if (!cachedMessages.isEmpty() && cachedMessages.size() >= sizePlusOne) {
+            return toChatMessages(cachedMessages);
+        }
+
+        // db 조회
         CursorToken cursorToken = parseCursor(rawCursor);
 
         return messageService.findMessages(room.getId(), cursorToken.createdAt(), cursorToken.id(), sizePlusOne);

--- a/mokakbob-api/src/main/java/com/mokakbob/chat/service/ChatApiService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/service/ChatApiService.java
@@ -2,8 +2,11 @@ package com.mokakbob.chat.service;
 
 import com.mokakbob.chat.controller.response.ChatRoomResponse;
 import com.mokakbob.chat.controller.response.ChatRoomResponses;
+import com.mokakbob.chat.exception.ChatErrorCode;
+import com.mokakbob.chat.service.support.CursorToken;
 import com.mokakbob.chat.service.support.ParticipantContext;
 import com.mokakbob.chat.util.ChatRoomMapper;
+import com.mokakbob.common.exception.exceptions.ApiException;
 import com.mokakbob.domain.chat.domain.ChatMessage;
 import com.mokakbob.domain.chat.domain.ChatRoom;
 import com.mokakbob.domain.chat.pubsub.ChatPublisher;
@@ -59,11 +62,15 @@ public class ChatApiService {
     }
 
     @Transactional(readOnly = true)
-    public List<ChatMessage> findChatMessages(Long memberId, Long roomId, LocalDateTime cursor, Integer size) {
+    public List<ChatMessage> findChatMessages(Long memberId, Long roomId, String rawCursor, Integer size) {
         ChatRoom room = findChatRoom(roomId, memberId);
-        int finalSize = normalizeSize(size);
 
-        return messageService.findMessages(room.getId(), cursor, finalSize + HAS_NEXT_DELIMITER);
+        int pageSize = normalizeSize(size);
+        int sizePlusOne = pageSize + HAS_NEXT_DELIMITER;
+
+        CursorToken cursorToken = parseCursor(rawCursor);
+
+        return messageService.findMessages(room.getId(), cursorToken.createdAt(), cursorToken.id(), sizePlusOne);
     }
 
     private int normalizeSize(Integer size) {
@@ -72,6 +79,25 @@ public class ChatApiService {
         }
 
         return Math.min(size, MAX_MESSAGE_SIZE);
+    }
+
+    /**
+     * "createdAt|id" 형태의 커서 문자열을 파싱한다. - null 또는 빈 문자열이면 비어 있는 CursorToken 반환
+     */
+    private CursorToken parseCursor(String rawCursor) {
+        if (rawCursor == null || rawCursor.isBlank()) {
+            return new CursorToken(null, null);
+        }
+
+        String[] parts = rawCursor.split("\\|");
+        if (parts.length != 2) {
+            throw new ApiException(ChatErrorCode.NOT_SUPPORT_CURSOR_FORMAT);
+        }
+
+        LocalDateTime createdAt = LocalDateTime.parse(parts[0]);
+        Long id = Long.parseLong(parts[1]);
+
+        return new CursorToken(createdAt, id);
     }
 
     /**

--- a/mokakbob-api/src/main/java/com/mokakbob/chat/service/ChatApiService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/service/ChatApiService.java
@@ -34,6 +34,7 @@ public class ChatApiService {
     private static final int DEFAULT_MESSAGE_SIZE = 30;
     private static final int MAX_MESSAGE_SIZE = 100;
     private static final int ZERO_MESSAGE_SIZE = 0;
+    private static final int HAS_NEXT_DELIMITER = 1;
     private static final String PAGING_SORT_DELIMITER = "id";
 
     private final ChatPublisher chatPublisher;
@@ -62,13 +63,14 @@ public class ChatApiService {
         ChatRoom room = findChatRoom(roomId, memberId);
         int finalSize = normalizeSize(size);
 
-        return messageService.findMessages(room.getId(), cursor, finalSize);
+        return messageService.findMessages(room.getId(), cursor, finalSize + HAS_NEXT_DELIMITER);
     }
 
     private int normalizeSize(Integer size) {
         if (size == null || size <= ZERO_MESSAGE_SIZE) {
             return DEFAULT_MESSAGE_SIZE;
         }
+
         return Math.min(size, MAX_MESSAGE_SIZE);
     }
 

--- a/mokakbob-api/src/main/java/com/mokakbob/chat/service/ChatApiService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/service/ChatApiService.java
@@ -75,8 +75,7 @@ public class ChatApiService {
         int sizePlusOne = pageSize + HAS_NEXT_DELIMITER;
 
         // redis 조회
-        List<CachedChatMessage> cachedMessages =
-                chatMessageStore.loadMessages(room.getId(), rawCursor, sizePlusOne);
+        List<CachedChatMessage> cachedMessages = chatMessageStore.loadMessages(room.getId(), rawCursor, sizePlusOne);
 
         if (!cachedMessages.isEmpty() && cachedMessages.size() >= sizePlusOne) {
             return toChatMessages(cachedMessages);
@@ -97,14 +96,14 @@ public class ChatApiService {
     }
 
     /**
-     * "createdAt|id" 형태의 커서 문자열을 파싱한다. - null 또는 빈 문자열이면 비어 있는 CursorToken 반환
+     * "createdAt_id" 형태의 커서 문자열을 파싱한다. - null 또는 빈 문자열이면 비어 있는 CursorToken 반환
      */
     private CursorToken parseCursor(String rawCursor) {
         if (rawCursor == null || rawCursor.isBlank()) {
             return new CursorToken(null, null);
         }
 
-        String[] parts = rawCursor.split("\\|");
+        String[] parts = rawCursor.split("_");
         if (parts.length != 2) {
             throw new ApiException(ChatErrorCode.NOT_SUPPORT_CURSOR_FORMAT);
         }

--- a/mokakbob-api/src/main/java/com/mokakbob/chat/service/ChatApiService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/service/ChatApiService.java
@@ -3,7 +3,7 @@ package com.mokakbob.chat.service;
 import com.mokakbob.chat.controller.response.ChatRoomResponse;
 import com.mokakbob.chat.controller.response.ChatRoomResponses;
 import com.mokakbob.chat.exception.ChatErrorCode;
-import com.mokakbob.chat.service.support.CursorToken;
+import com.mokakbob.domain.chat.cursor.CursorToken;
 import com.mokakbob.chat.service.support.ParticipantContext;
 import com.mokakbob.chat.util.ChatRoomMapper;
 import com.mokakbob.common.exception.exceptions.ApiException;

--- a/mokakbob-api/src/main/java/com/mokakbob/chat/service/ChatApiService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/service/ChatApiService.java
@@ -53,7 +53,8 @@ public class ChatApiService {
 
     @Transactional
     public void handleMessage(Long roomId, String memberId, String content, long sendAt) {
-        messageService.saveChatMessage(roomId, Long.valueOf(memberId), content);
+        ChatMessage chatMessage = messageService.saveChatMessage(roomId, Long.valueOf(memberId), content);
+        chatMessageStore.cacheMessage(chatMessage);
         chatPublisher.publish(roomId, new ChatMessageResponse(roomId, memberId, content, sendAt));
     }
 

--- a/mokakbob-api/src/main/java/com/mokakbob/chat/service/ChatApiService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/service/ChatApiService.java
@@ -4,6 +4,7 @@ import com.mokakbob.chat.controller.response.ChatRoomResponse;
 import com.mokakbob.chat.controller.response.ChatRoomResponses;
 import com.mokakbob.chat.service.support.ParticipantContext;
 import com.mokakbob.chat.util.ChatRoomMapper;
+import com.mokakbob.domain.chat.domain.ChatMessage;
 import com.mokakbob.domain.chat.domain.ChatRoom;
 import com.mokakbob.domain.chat.pubsub.ChatPublisher;
 import com.mokakbob.domain.chat.pubsub.response.ChatMessageResponse;
@@ -14,6 +15,7 @@ import com.mokakbob.domain.matching.domain.MatchingParticipant;
 import com.mokakbob.domain.matching.service.MatchingParticipateService;
 import com.mokakbob.domain.member.domain.Member;
 import com.mokakbob.domain.member.service.MemberService;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -29,6 +31,9 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ChatApiService {
 
+    private static final int DEFAULT_MESSAGE_SIZE = 30;
+    private static final int MAX_MESSAGE_SIZE = 100;
+    private static final int ZERO_MESSAGE_SIZE = 0;
     private static final String PAGING_SORT_DELIMITER = "id";
 
     private final ChatPublisher chatPublisher;
@@ -50,6 +55,21 @@ public class ChatApiService {
         participateService.validateMatchingParticipant(matching.getId(), memberId);
 
         return room;
+    }
+
+    @Transactional(readOnly = true)
+    public List<ChatMessage> findChatMessages(Long memberId, Long roomId, LocalDateTime cursor, Integer size) {
+        ChatRoom room = findChatRoom(roomId, memberId);
+        int finalSize = normalizeSize(size);
+
+        return messageService.findMessages(room.getId(), cursor, finalSize);
+    }
+
+    private int normalizeSize(Integer size) {
+        if (size == null || size <= ZERO_MESSAGE_SIZE) {
+            return DEFAULT_MESSAGE_SIZE;
+        }
+        return Math.min(size, MAX_MESSAGE_SIZE);
     }
 
     /**

--- a/mokakbob-api/src/main/java/com/mokakbob/chat/service/support/CursorToken.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/service/support/CursorToken.java
@@ -1,0 +1,13 @@
+package com.mokakbob.chat.service.support;
+
+import java.time.LocalDateTime;
+
+public record CursorToken(
+        LocalDateTime createdAt,
+        Long id
+) {
+
+    public boolean isEmpty() {
+        return createdAt == null || id == null;
+    }
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/chat/util/ChatMessageMapper.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/chat/util/ChatMessageMapper.java
@@ -1,0 +1,22 @@
+package com.mokakbob.chat.util;
+
+import com.mokakbob.domain.chat.cache.CachedChatMessage;
+import com.mokakbob.domain.chat.domain.ChatMessage;
+import java.util.List;
+
+public class ChatMessageMapper {
+
+    public static List<ChatMessage> toChatMessages(List<CachedChatMessage> cachedMessages) {
+        return cachedMessages.stream()
+                .map(ChatMessageMapper::toChatMessage)
+                .toList();
+    }
+
+    private static ChatMessage toChatMessage(CachedChatMessage cached) {
+        return ChatMessage.builder()
+                .chatRoomId(cached.chatRoomId())
+                .senderId(cached.senderId())
+                .message(cached.content())
+                .build();
+    }
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/common/path/chat/ChatPath.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/common/path/chat/ChatPath.java
@@ -4,6 +4,8 @@ public class ChatPath {
 
     public static final String ROOMS = "/api/v1/chat/rooms";
     public static final String ENTER = "/api/v1/chat/enter";
+    public static final String MESSAGES = "/api/v1/chat/rooms/{roomId}/messages";
+
     public static final String WS = "/ws-connect";
     public static final String PUB = "/pub/chat";
     public static final String SUB = "/sub/chat";

--- a/mokakbob-core/src/main/java/com/mokakbob/cache/ChatMessageStore.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/cache/ChatMessageStore.java
@@ -1,0 +1,12 @@
+package com.mokakbob.cache;
+
+import com.mokakbob.domain.chat.cache.CachedChatMessage;
+import com.mokakbob.domain.chat.domain.ChatMessage;
+import java.util.List;
+
+public interface ChatMessageStore {
+
+    void cacheMessage(ChatMessage message);
+
+    List<CachedChatMessage> loadMessages(Long roomId, String rawCursor, int sizePlusOne);
+}

--- a/mokakbob-core/src/main/java/com/mokakbob/common/domain/BaseEntity.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/common/domain/BaseEntity.java
@@ -4,10 +4,12 @@ import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
+import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+@Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseEntity {

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/chat/cache/CachedChatMessage.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/chat/cache/CachedChatMessage.java
@@ -1,0 +1,12 @@
+package com.mokakbob.domain.chat.cache;
+
+import java.time.LocalDateTime;
+
+public record CachedChatMessage(
+        Long id,
+        Long chatRoomId,
+        Long senderId,
+        String content,
+        LocalDateTime createdAt
+) {
+}

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/chat/cursor/CursorToken.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/chat/cursor/CursorToken.java
@@ -1,4 +1,4 @@
-package com.mokakbob.chat.service.support;
+package com.mokakbob.domain.chat.cursor;
 
 import java.time.LocalDateTime;
 

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/chat/repository/ChatMessageRepository.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/chat/repository/ChatMessageRepository.java
@@ -17,7 +17,7 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
         SELECT m
         FROM ChatMessage m
         WHERE m.chatRoomId = :roomId
-        ORDER BY m.createdAt DESC
+        ORDER BY m.createdAt DESC, m.id DESC
     """)
     List<ChatMessage> findLatestMessages(
             @Param("roomId") Long roomId,
@@ -29,12 +29,16 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
         SELECT m
         FROM ChatMessage m
         WHERE m.chatRoomId = :roomId
-          AND m.createdAt < :cursor
-        ORDER BY m.createdAt DESC
+          AND (
+                m.createdAt < :cursorCreatedAt
+                OR (m.createdAt = :cursorCreatedAt AND m.id < :cursorId)
+          )
+        ORDER BY m.createdAt DESC, m.id DESC
     """)
     List<ChatMessage> findMessagesByCursor(
             @Param("roomId") Long roomId,
-            @Param("cursor") LocalDateTime cursor,
+            @Param("cursorCreatedAt") LocalDateTime cursorCreatedAt,
+            @Param("cursorId") Long cursorId,
             Pageable pageable
     );
 }

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/chat/repository/ChatMessageRepository.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/chat/repository/ChatMessageRepository.java
@@ -1,9 +1,40 @@
 package com.mokakbob.domain.chat.repository;
 
 import com.mokakbob.domain.chat.domain.ChatMessage;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+
+    // cursor가 없는 경우
+    @Query("""
+        SELECT m
+        FROM ChatMessage m
+        WHERE m.chatRoomId = :roomId
+        ORDER BY m.createdAt DESC
+    """)
+    List<ChatMessage> findLatestMessages(
+            @Param("roomId") Long roomId,
+            Pageable pageable
+    );
+
+    // cursor가 있는 경우
+    @Query("""
+        SELECT m
+        FROM ChatMessage m
+        WHERE m.chatRoomId = :roomId
+          AND m.createdAt < :cursor
+        ORDER BY m.createdAt DESC
+    """)
+    List<ChatMessage> findMessagesByCursor(
+            @Param("roomId") Long roomId,
+            @Param("cursor") LocalDateTime cursor,
+            Pageable pageable
+    );
 }

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/chat/service/ChatMessageService.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/chat/service/ChatMessageService.java
@@ -2,7 +2,11 @@ package com.mokakbob.domain.chat.service;
 
 import com.mokakbob.domain.chat.domain.ChatMessage;
 import com.mokakbob.domain.chat.repository.ChatMessageRepository;
+import java.time.LocalDateTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,5 +25,16 @@ public class ChatMessageService {
                 .build();
 
         messageRepository.save(chatMessage);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ChatMessage> findMessages(Long roomId, LocalDateTime cursor, int size) {
+        Pageable pageable = PageRequest.of(0, size);
+
+        if (cursor == null) {
+            return messageRepository.findLatestMessages(roomId, pageable);
+        }
+
+        return messageRepository.findMessagesByCursor(roomId, cursor, pageable);
     }
 }

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/chat/service/ChatMessageService.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/chat/service/ChatMessageService.java
@@ -14,6 +14,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ChatMessageService {
 
+    private static final int DEFAULT_PAGE_OFFSET = 0;
+
     private final ChatMessageRepository messageRepository;
 
     @Transactional
@@ -28,8 +30,8 @@ public class ChatMessageService {
     }
 
     @Transactional(readOnly = true)
-    public List<ChatMessage> findMessages(Long roomId, LocalDateTime cursor, int size) {
-        Pageable pageable = PageRequest.of(0, size);
+    public List<ChatMessage> findMessages(Long roomId, LocalDateTime cursor, int sizePlusOne) {
+        Pageable pageable = PageRequest.of(DEFAULT_PAGE_OFFSET, sizePlusOne);
 
         if (cursor == null) {
             return messageRepository.findLatestMessages(roomId, pageable);

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/chat/service/ChatMessageService.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/chat/service/ChatMessageService.java
@@ -29,14 +29,17 @@ public class ChatMessageService {
         messageRepository.save(chatMessage);
     }
 
+    /**
+     * 복합 커서 기반 메시지 조회 (size+1 전략 포함)
+     */
     @Transactional(readOnly = true)
-    public List<ChatMessage> findMessages(Long roomId, LocalDateTime cursor, int sizePlusOne) {
+    public List<ChatMessage> findMessages(Long roomId, LocalDateTime cursorCreatedAt, Long cursorId, int sizePlusOne) {
         Pageable pageable = PageRequest.of(DEFAULT_PAGE_OFFSET, sizePlusOne);
 
-        if (cursor == null) {
+        if (cursorCreatedAt == null || cursorId == null) {
             return messageRepository.findLatestMessages(roomId, pageable);
         }
 
-        return messageRepository.findMessagesByCursor(roomId, cursor, pageable);
+        return messageRepository.findMessagesByCursor(roomId, cursorCreatedAt, cursorId, pageable);
     }
 }

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/chat/service/ChatMessageService.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/chat/service/ChatMessageService.java
@@ -19,14 +19,14 @@ public class ChatMessageService {
     private final ChatMessageRepository messageRepository;
 
     @Transactional
-    public void saveChatMessage(Long roomId, Long senderId, String message) {
+    public ChatMessage saveChatMessage(Long roomId, Long senderId, String message) {
         ChatMessage chatMessage = ChatMessage.builder()
                 .chatRoomId(roomId)
                 .senderId(senderId)
                 .message(message)
                 .build();
 
-        messageRepository.save(chatMessage);
+        return messageRepository.save(chatMessage);
     }
 
     /**

--- a/mokakbob-redis/src/main/java/com/mokakbob/chat/RedisMessageStore.java
+++ b/mokakbob-redis/src/main/java/com/mokakbob/chat/RedisMessageStore.java
@@ -17,7 +17,7 @@ public class RedisMessageStore implements ChatMessageStore {
 
     private static final String CHAT_ROOM_MESSAGES_KEY = "chat:room:%d:messages";
     private static final int CACHE_LIMIT = 200;
-    private static final String DELIMITER = "\\|";
+    private static final String DELIMITER = "_";
     private static final String SERIALIZE_DELIMITER = "|";
     private static final int REDIS_SCAN_END = CACHE_LIMIT - 1;
     private static final int SERIALIZE_PARTS = 5;

--- a/mokakbob-redis/src/main/java/com/mokakbob/chat/RedisMessageStore.java
+++ b/mokakbob-redis/src/main/java/com/mokakbob/chat/RedisMessageStore.java
@@ -1,0 +1,118 @@
+package com.mokakbob.chat;
+
+import com.mokakbob.cache.ChatMessageStore;
+import com.mokakbob.domain.chat.cache.CachedChatMessage;
+import com.mokakbob.domain.chat.cursor.CursorToken;
+import com.mokakbob.domain.chat.domain.ChatMessage;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisMessageStore implements ChatMessageStore {
+
+    private static final String CHAT_ROOM_MESSAGES_KEY = "chat:room:%d:messages";
+    private static final int CACHE_LIMIT = 200;
+    private static final String DELIMITER = "\\|";
+    private static final String SERIALIZE_DELIMITER = "|";
+    private static final int REDIS_SCAN_END = CACHE_LIMIT - 1;
+    private static final int SERIALIZE_PARTS = 5;
+
+    private final StringRedisTemplate redis;
+
+    @Override
+    public void cacheMessage(ChatMessage msg) {
+        String key = key(msg.getChatRoomId());
+        redis.opsForList().leftPush(key, serialize(msg));
+        redis.opsForList().trim(key, 0, CACHE_LIMIT - 1);
+    }
+
+    @Override
+    public List<CachedChatMessage> loadMessages(Long roomId, String rawCursor, int sizePlusOne) {
+        String key = key(roomId);
+
+        return (rawCursor == null || rawCursor.isBlank())
+                ? loadLatest(key, sizePlusOne)
+                : loadOlderThanCursor(key, parseCursor(rawCursor), sizePlusOne);
+    }
+
+    private List<CachedChatMessage> loadLatest(String key, int sizePlusOne) {
+        List<String> raw = redis.opsForList().range(key, 0, sizePlusOne - 1);
+
+        return deserializeList(raw);
+    }
+
+    private List<CachedChatMessage> loadOlderThanCursor(String key, CursorToken cursor, int sizePlusOne) {
+        List<String> all = redis.opsForList().range(key, 0, REDIS_SCAN_END);
+
+        if (all == null || all.isEmpty()) {
+            return List.of();
+        }
+
+        List<CachedChatMessage> result = new ArrayList<>();
+
+        for (String raw : all) {
+            CachedChatMessage msg = deserialize(raw);
+
+            if (isOlder(msg, cursor)) {
+                result.add(msg);
+
+                if (result.size() >= sizePlusOne) {
+                    break;
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private boolean isOlder(CachedChatMessage msg, CursorToken cursor) {
+        if (msg.createdAt().isBefore(cursor.createdAt())) {
+            return true;
+        }
+
+        return msg.createdAt().isEqual(cursor.createdAt()) && msg.id() < cursor.id();
+    }
+
+    private List<CachedChatMessage> deserializeList(List<String> rawList) {
+        if (rawList == null) {
+            return List.of();
+        }
+
+        return rawList.stream().map(this::deserialize).toList();
+    }
+
+    private String key(Long roomId) {
+        return String.format(CHAT_ROOM_MESSAGES_KEY, roomId);
+    }
+
+    private String serialize(ChatMessage m) {
+        return m.getCreatedAt() + SERIALIZE_DELIMITER
+                + m.getId() + SERIALIZE_DELIMITER
+                + m.getChatRoomId() + SERIALIZE_DELIMITER
+                + m.getSenderId() + SERIALIZE_DELIMITER
+                + m.getMessage();
+    }
+
+    private CachedChatMessage deserialize(String raw) {
+        String[] p = raw.split(DELIMITER, SERIALIZE_PARTS);
+
+        return new CachedChatMessage(
+                Long.parseLong(p[1]),
+                Long.parseLong(p[2]),
+                Long.parseLong(p[3]),
+                p[4],
+                LocalDateTime.parse(p[0])
+        );
+    }
+
+    private CursorToken parseCursor(String cursor) {
+        String[] p = cursor.split(DELIMITER);
+
+        return new CursorToken(LocalDateTime.parse(p[0]), Long.parseLong(p[1]));
+    }
+}


### PR DESCRIPTION
## 관련 이슈 번호
* #121 closed

## 작업 내용 (25.12.02)
* 채팅 히스토리 조회 API 구현
* 채팅 히스토리는 최근 메시지를 중심으로 높은 조회 빈도를 갖기 때문에, 일관성 + 빠른 조회(고성능) + DB I/O 최소화 할 수 있는 방법으로 구현하고자 함

### 커서 기반 조회
* 커서 기반 조회 선택 이유
  * 기존의 `offset` 방식의 조회에는 다음과 같은 문제점이 있음.
     * 데이터가 쌓일 수록 페이징은 정렬 안정성이 떨어지고, 이 과정에서 데이터 누락이나 중복 발생 가능성 있음.
     * `offset` 이 증가할 수록 스캔해야하는 row 수 증가
     * 다음 페이지 조회를 위한 `COUNT` 쿼리로 인해 병목 발생 가능성 존재 
  * 따라서, 읽은 메시지를 기준으로 하는 커서 기반 조회 도입

* 구현 방식
  * 클라이언트가 전달한 커서 기준으로, `size + 1` 만큼 조회해서 다음 조회 항목이 있는지 확인.
  * 해당 방식으로 `COUNT(*)` 하지 않고 다음 데이터가 존재하는지 확인 가능

### 복합 커서(createdAt + id) 구현
* 단일 커서(`createdAt`)가 부족한 이유
  * 채팅 시스템에서는 동일한 타임스탬프에 여러 메시지가 들어올 가능성이 매우 높음. 
  * 따라서, 단일 커서만 사용 시, 데이터 정렬 조건과 커서 기준이 꼬여서 중복 / 누락 발생할 수 있음.

* 구현 방식
  * `{createdAt}_{id}` 해당 방식으로 구성하여 파싱해서 사용
  * 정렬 조건(`ORDER BY createdAt DESC, id DESC`)과 커서 조건이 동일해짐.

### Redis 기반 캐싱
* 캐싱 도입 이유
  * DB I/O 감소를 통해 메시지 저장/조회 성능 크게 향상시키기 위함.

* 구현 방식
  * 커서가 없는 경우(첫 조회), 최신 메시지를 `size + 1` 만큼 조회
  * 커서가 있는 경우,  Redis 범위(최근 200개)에서 커서 기준 필터링
  * 캐시 미스 or 부족 시 DB fallback


## 고려 사항
* `createdAt + id `복합 인덱스 튜닝 고려