### PR TITLE
#124 [FEAT] iamport 결제 검증 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ allprojects {
 
 	repositories {
 		mavenCentral()
+		maven { url "https://jitpack.io" }
 	}
 }
 

--- a/mokakbob-api/build.gradle
+++ b/mokakbob-api/build.gradle
@@ -41,6 +41,9 @@ dependencies {
 
     // websocket
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
+    // iamport
+    implementation 'com.github.iamport:iamport-rest-client-java:0.2.23'
 }
 
 springBoot {

--- a/mokakbob-api/src/main/java/com/mokakbob/point/config/IamportConfig.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/point/config/IamportConfig.java
@@ -1,0 +1,21 @@
+package com.mokakbob.point.config;
+
+import com.siot.IamportRestClient.IamportClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class IamportConfig {
+
+    @Value("${iamport.api-key}")
+    private String apiKey;
+
+    @Value("${iamport.api-secret}")
+    private String apiSecret;
+
+    @Bean
+    public IamportClient iamportClient() {
+        return new IamportClient(apiKey, apiSecret);
+    }
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/point/exception/PointErrorCode.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/point/exception/PointErrorCode.java
@@ -1,0 +1,35 @@
+package com.mokakbob.point.exception;
+
+import com.mokakbob.common.exception.exceptions.ApiErrorCode;
+
+public enum PointErrorCode implements ApiErrorCode {
+
+    PAYMENT_GATEWAY_ERROR(500, "P001", "결제 승인 서버와의 통신 중 오류가 발생했습니다."),
+    INVALID_PAYMENT(400, "P002", "유효하지 않은 결제입니다.")
+    ;
+
+    private final int httpStatus;
+    private final String customCode;
+    private final String message;
+
+    PointErrorCode(int httpStatus, String customCode, String message) {
+        this.httpStatus = httpStatus;
+        this.customCode = customCode;
+        this.message = message;
+    }
+
+    @Override
+    public int httpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String customCode() {
+        return customCode;
+    }
+
+    @Override
+    public String message() {
+        return message;
+    }
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/point/infrastructure/IamportPaymentVerificationPort.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/point/infrastructure/IamportPaymentVerificationPort.java
@@ -1,0 +1,48 @@
+package com.mokakbob.point.infrastructure;
+
+import com.mokakbob.common.exception.exceptions.ApiException;
+import com.mokakbob.domain.point.port.PaymentVerificationPort;
+import com.mokakbob.domain.point.port.dto.VerifiedPayment;
+import com.mokakbob.point.exception.PointErrorCode;
+import com.siot.IamportRestClient.IamportClient;
+import com.siot.IamportRestClient.response.IamportResponse;
+import com.siot.IamportRestClient.response.Payment;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class IamportPaymentVerificationPort implements PaymentVerificationPort {
+
+    private final IamportClient iamportClient;
+
+    @Override
+    public VerifiedPayment verify(String impUid, String merchantUid) {
+        try {
+            IamportResponse<Payment> response = iamportClient.paymentByImpUid(impUid);
+            Payment payment = response.getResponse();
+
+            if (payment == null) {
+                log.warn("[Iamport] 결제 정보 없음 impUid={}, merchantUid={}", impUid, merchantUid);
+                throw new ApiException(PointErrorCode.INVALID_PAYMENT);
+            }
+
+            return new VerifiedPayment(
+                    payment.getImpUid(),
+                    payment.getMerchantUid(),
+                    payment.getAmount().intValueExact(),
+                    payment.getStatus(),
+                    payment.getPgProvider()
+            );
+
+        } catch (ApiException e) {
+            throw e;
+
+        } catch (Exception e) {
+            log.error("[Iamport] 결제 검증 중 오류 impUid={}, merchantUid={}", impUid, merchantUid, e);
+            throw new ApiException(PointErrorCode.PAYMENT_GATEWAY_ERROR);
+        }
+    }
+}

--- a/mokakbob-api/src/main/java/com/mokakbob/point/service/IamportVerificationService.java
+++ b/mokakbob-api/src/main/java/com/mokakbob/point/service/IamportVerificationService.java
@@ -1,0 +1,34 @@
+package com.mokakbob.point.service;
+
+import com.mokakbob.common.exception.exceptions.ApiException;
+import com.mokakbob.domain.point.port.PaymentVerificationPort;
+import com.mokakbob.domain.point.port.dto.VerifiedPayment;
+import com.mokakbob.point.exception.PointErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class IamportVerificationService {
+
+    private static final String PAID_STATUS = "paid";
+
+    private final PaymentVerificationPort verificationPort;
+
+    public VerifiedPayment verify(String impUid, String merchantUid) {
+
+        VerifiedPayment verified = verificationPort.verify(impUid, merchantUid);
+
+        // 결제 상태 확인
+        if (!PAID_STATUS.equalsIgnoreCase(verified.status())) {
+            throw new ApiException(PointErrorCode.INVALID_PAYMENT);
+        }
+
+        // merchantUid 일치 여부 확인
+        if (!merchantUid.equals(verified.merchantUid())) {
+            throw new ApiException(PointErrorCode.INVALID_PAYMENT);
+        }
+
+        return verified;
+    }
+}

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/point/port/PaymentVerificationPort.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/point/port/PaymentVerificationPort.java
@@ -1,0 +1,8 @@
+package com.mokakbob.domain.point.port;
+
+import com.mokakbob.domain.point.port.dto.VerifiedPayment;
+
+public interface PaymentVerificationPort {
+
+    VerifiedPayment verify(String impUid, String merchantUid);
+}

--- a/mokakbob-core/src/main/java/com/mokakbob/domain/point/port/dto/VerifiedPayment.java
+++ b/mokakbob-core/src/main/java/com/mokakbob/domain/point/port/dto/VerifiedPayment.java
@@ -1,0 +1,10 @@
+package com.mokakbob.domain.point.port.dto;
+
+public record VerifiedPayment(
+        String impUid,
+        String merchantUid,
+        int amount,
+        String status,
+        String pgProvider
+) {
+}


### PR DESCRIPTION
## 관련 이슈 번호
 - #124 closed

## 작업 내용

### iamport 결제 검증 기능 구현 (Port-Adapter 구조 기반)
- 외부 PG(Iamport)와의 통신을 담당하는 `PaymentVerificationPort` 인터페이스 정의
- PG 결제 상태 및 merchantUid 검증 수행

### Port 구현체(Iamport Adapter) 추가
- `IamportPaymentVerificationPort` 구현체 구현
- Iamport SDK를 통해 impUid 기반 결제 정보 조회
- payment == null 또는 PG 서버 오류 케이스에 대한 방어 로직 추가

### PG 검증 조건 강화
- 결제 상태(status)가 `paid` 가 아닐 경우 검증 실패 처리
- 요청 merchantUid 와 PG 응답 merchantUid 불일치 시 검증 실패 처리

## 참고사항
- 이번 PR은 "PG 결제 검증"에 한정된 기능 구현,
-  금액 검증 / 중복 결제 검사 / Payment 저장 / Point 충전 기능 구현 필요